### PR TITLE
Labguide skeleton

### DIFF
--- a/labguide/_cns_testdrive.yaml
+++ b/labguide/_cns_testdrive.yaml
@@ -3,7 +3,7 @@ id: ocp-cns-testdrive
 name: OpenShift for Operators with Container Native Storage
 
 content:
-  url: https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/production
+  url: https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/production/labguide
 
 vars:
   ENVIRONMENT: "Amazon Web Services"

--- a/labguide/_cns_testdrive.yaml
+++ b/labguide/_cns_testdrive.yaml
@@ -1,0 +1,16 @@
+---
+id: ocp-cns-testdrive
+name: OpenShift for Operators with Container Native Storage
+
+content:
+  url: https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/production
+
+vars:
+  ENVIRONMENT: "Amazon Web Services"
+  MASTERS: "1"
+  INFRA: "1"
+  NODES: "3"
+
+modules:
+  activate:
+  - environment

--- a/labguide/_modules.yml
+++ b/labguide/_modules.yml
@@ -1,0 +1,12 @@
+modules:
+  environment:
+    name: Environment Overview
+    vars:
+      MASTERS:
+      INFRA:
+      NODES:
+      NFS_ENABLED:
+      LOGGING_ENABLED:
+      ETHERPAD_ENABLED:
+      NUM_USERS:
+      ETHERPAD_URL_PREFIX:

--- a/labguide/environment.adoc
+++ b/labguide/environment.adoc
@@ -1,0 +1,7 @@
+## Environment Overview
+
+You will be interacting with an OpenShift environment that is running on {{ ENVIRONMENT }}. The environment consists of the following systems:
+
+* {{ MASTERS }} master nodes
+* {{ INFRA }} infrastructure nodes
+* {{ NODES }} "application" nodes


### PR DESCRIPTION
This PR creates a labguide folder with the bare minimum amount of files to start messing with workshopper.

If you fork this repo and create your own branch, you can run a container on your local system with a similar incantation to the below. It will make the lab guide available on http://localhost:8080 and source content from your fork/branch:

```
docker run -p 8080:8080 \
-e WORKSHOPS_URLS="https://raw.githubusercontent.com/YOURUSER/openshift-cns-testdrive/YOURBRANCH/labguide/_cns_testdrive.yaml" \
-e CONTENT_URL_PREFIX="https://raw.githubusercontent.com/YOURUSER/openshift-cns-testdrive/YOURBRANCH/labguide/" \
osevg/workshopper:0.1
```