### PR TITLE
adding files to packer/roles/workshopper/files  

### DIFF
--- a/packer/roles/workshopper/files/docker-lab.service
+++ b/packer/roles/workshopper/files/docker-lab.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Lab guide container
+After=docker.service
+Requires=docker.service
+
+[Service]
+EnvironmentFile=/etc/sysconfig/workshopper
+#ExecStartPre=-/usr/bin/docker create --name %n -p 80:8080 --env-file /etc/sysconfig/workshopper docker.io/osevg/workshopper:0.1
+ExecStart=/opt/bin/systemd-docker --env run --rm --name %n -p 80:8080 docker.io/osevg/workshopper:0.1
+Restart=always
+RestartSec=10s
+Type=notify
+NotifyAccess=all
+TimeoutStartSec=120
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target
+

--- a/packer/roles/workshopper/files/docker-lab.service
+++ b/packer/roles/workshopper/files/docker-lab.service
@@ -1,11 +1,10 @@
 [Unit]
-Description=Lab guide container
+Description=Workshopper Lab Guide
 After=docker.service
 Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/workshopper
-#ExecStartPre=-/usr/bin/docker create --name %n -p 80:8080 --env-file /etc/sysconfig/workshopper docker.io/osevg/workshopper:0.1
 ExecStart=/opt/bin/systemd-docker --env run --rm --name %n -p 80:8080 docker.io/osevg/workshopper:0.1
 Restart=always
 RestartSec=10s

--- a/packer/roles/workshopper/files/workshopper
+++ b/packer/roles/workshopper/files/workshopper
@@ -1,2 +1,2 @@
-WORKSHOPS_URLS="https://raw.githubusercontent.com/kmurudi/openshift-cns-testdrive/master/labguide/_cns_testdrive.yaml" 
-CONTENT_URL_PREFIX="https://raw.githubusercontent.com/kmurudi/openshift-cns-testdrive/master/labguide/"
+WORKSHOPS_URLS="https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/production/labguide/_cns_testdrive.yaml" 
+CONTENT_URL_PREFIX="https://raw.githubusercontent.com/openshift/openshift-cns-testdrive/production/labguide/"

--- a/packer/roles/workshopper/files/workshopper
+++ b/packer/roles/workshopper/files/workshopper
@@ -1,0 +1,2 @@
+WORKSHOPS_URLS="https://raw.githubusercontent.com/kmurudi/openshift-cns-testdrive/master/labguide/_cns_testdrive.yaml" 
+CONTENT_URL_PREFIX="https://raw.githubusercontent.com/kmurudi/openshift-cns-testdrive/master/labguide/"

--- a/packer/roles/workshopper/files/workshopper.service
+++ b/packer/roles/workshopper/files/workshopper.service
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/workshopper
-ExecStart=/opt/bin/systemd-docker --env run --rm --name %n -p 80:8080 docker.io/osevg/workshopper:0.1
+ExecStart=/usr/bin/systemd-docker --env run --rm --name %n -p 80:8080 docker.io/osevg/workshopper:0.1
 Restart=always
 RestartSec=10s
 Type=notify


### PR DESCRIPTION
added the systemd script for running the lab guide container loaded with environment variables obtained from the config file (path = /etc/sysconfig/workshopper , named - workshopper)
systemd script path = /etc/systemd/system/multi-user.target.wants, name=docker-lab.service

the script uses the binary file - systemd-docker(which I have added here too /workshopper/files/), which works as a wrapper, allowing docker containers to run under systemd

to start the lab guide - systemctl start docker-lab
connect browser to - http://localhost:80 to view lab guide content
to stop the lab guide - systemctl stop docker-lab

to restart - systemctl restart docker-lab (shows a failure once, run it again, restarts it fine)

