### PR TITLE
enable workshopper with updated AMI

### DIFF
--- a/cloudformation/qwiklabs-cloudformation.yml
+++ b/cloudformation/qwiklabs-cloudformation.yml
@@ -745,6 +745,7 @@ Resources:
             cloud_config_modules:
             - disk_setup
             - mounts
+            - runcmd
 
             fqdn: guide.${QwiklabId}.${PublicHostedZone}
 


### PR DESCRIPTION
- added newer AMI id, also to other supported regions
- explicitly called out unsupported regions
- fixed systemd-docker startup
- fixed cloud-init on labguide node
- fixed labguide node naming

At this point cloud-init seems to ignore our runcmd statements. Need to investigate.