### PR TITLE
Add skip ahead instructions module

### DIFF
--- a/labguide/_modules.yml
+++ b/labguide/_modules.yml
@@ -84,6 +84,8 @@ modules:
       CNS_STORAGECLASS: "cns-gold"
   cluster-mgmt-basics:
     name: Cluster Management Basics
+    requires:
+      - installation
   infra-mgmt-basics:
     name: Infrastructure Management Basics
     requires:
@@ -105,3 +107,5 @@ modules:
       CNS_NAMESPACE: "container-native-storage"
       NODE_BRICK_DEVICE: "/dev/xvdd"
       NODE_BRICK_DEVICE2: "/dev/xvde"
+  skipping-ahead:
+    name: Skipping modules

--- a/labguide/_modules.yml
+++ b/labguide/_modules.yml
@@ -56,6 +56,8 @@ config:
       value: "https://master.example.com/console"
     - name: API_HEALTH_URL
       value: "https://openshift.example.com/healthz/ready"
+    - name: CODE_CLONE_LOCATION
+      value: "/opt/lab/code"
 
 modules:
   environment:

--- a/labguide/_ocp_admin_testdrive.yaml
+++ b/labguide/_ocp_admin_testdrive.yaml
@@ -19,3 +19,4 @@ modules:
   - cluster-mgmt-basics
   - infra-mgmt-basics
   - cns-management
+  - skipping-ahead

--- a/labguide/skipping-ahead.adoc
+++ b/labguide/skipping-ahead.adoc
@@ -1,5 +1,5 @@
 [abstract]
-Overview
+Skipping Modules
 --------
 While the Test Drive is designed to be an experience that is linear in nature,
 it is possible to skip modules. Skipping modules requires that you perform
@@ -10,4 +10,34 @@ still rely on this being completed, so you must still make sure the steps have
 been executed.
 
 We provide automation of each module using Ansible playbooks that are located in
-the `{{ REPO_LOCATION }}/tests` folder.
+the `{{ CODE_CLONE_LOCATION }}/tests` folder.
+
+The Automation Playbooks
+--------
+There are two file suffixes in the `tests` folder:
+
+* `*_verification.yml`
+* `*_automation.yml`
+
+The verification playbook is used as a part of our test-driven development
+methodology for the Test Drive. You will not need to use it, although examining
+it may provide some insight into how we evaluate whether or not things are still
+working after updates and upgrades.
+
+The important playbook is the `*_automation.yml` file. These playbooks will
+perform all of the same steps that are in each module's instructions. The
+filenames for the playbooks will resemble the module names. For example, if the
+module is called *Deploying Container Native Storage*, you will find a file
+called `cns-deploy_automation.yml`.
+
+Executing the Playbooks
+--------
+Executing the skip module playbooks is trivial. Given the example above, SSH
+into the master host and, from anywhere on the host:
+
+----
+ansible-playbook /opt/lab/code/tests/cns-deploy_automation.yml
+----
+
+Eventually, Ansible will complete. If you wish to skip another module, just run
+its corresponding automation playbooks as above.

--- a/labguide/skipping-ahead.adoc
+++ b/labguide/skipping-ahead.adoc
@@ -1,0 +1,13 @@
+[abstract]
+Overview
+--------
+While the Test Drive is designed to be an experience that is linear in nature,
+it is possible to skip modules. Skipping modules requires that you perform
+certain automation tasks that will actually "do" the exercise for you.
+
+For example, if you wanted to skip user and group configuration, later labs
+still rely on this being completed, so you must still make sure the steps have
+been executed.
+
+We provide automation of each module using Ansible playbooks that are located in
+the `{{ REPO_LOCATION }}/tests` folder.


### PR DESCRIPTION
This adds a module that describes how to skip ahead by running the automation playbooks.