### PR TITLE
Fixes automation tests to use drain

### DIFF
--- a/cloudformation/qwiklabs-cloudformation.yml
+++ b/cloudformation/qwiklabs-cloudformation.yml
@@ -1044,9 +1044,9 @@ Resources:
                     #logging_openshift_logging_es_memory_limit=2G
                     #logging_openshift_logging_kibana_hostname=kibana.apps.${AWS::AccountId}.${PublicHostedZone}
                     #logging_openshift_logging_public_master_url=https://kibana.apps.${AWS::AccountId}.${PublicHostedZone}
+
+                    # prometheus configs (future)
                     openshift_hosted_prometheus_deploy=true
-                    openshift_image_tag=v3.9.30
-                    openshift_release_tag=v3.9.30
 
                     [etcd]
                     master.internal.${PublicHostedZone}

--- a/cloudformation/qwiklabs-cloudformation.yml
+++ b/cloudformation/qwiklabs-cloudformation.yml
@@ -978,16 +978,21 @@ Resources:
                     [OSEv3:vars]
                     ansible_become=true
                     deployment_type=openshift-enterprise
+                    openshift_disable_check=memory_availability,disk_availability,docker_storage,package_version,docker_image_availability,package_availability
                     containerized=true
+                    openshift_enable_service_catalog=false
+
                     openshift_master_api_port=443
                     openshift_master_console_port=443
                     openshift_master_identity_providers=[{'name': 'idm', 'challenge': 'true', 'login': 'true', 'kind': 'LDAPPasswordIdentityProvider', 'attributes': {'id': ['dn'], 'email': ['mail'], 'name': ['cn'], 'preferredUsername': ['uid']}, 'bindDN': 'uid=system,cn=sysaccounts,cn=etc,dc=auth,dc=internal,dc=aws,dc=testdrive,dc=openshift,dc=com', 'bindPassword': 'bindingpassword', 'ca': '/etc/origin/master/ipa-ca.crt', 'insecure': 'false', 'url': 'ldap://idm.internal.aws.testdrive.openshift.com/cn=users,cn=accounts,dc=auth,dc=internal,dc=aws,dc=testdrive,dc=openshift,dc=com?uid?sub?(memberOf=cn=ose-user,cn=groups,cn=accounts,dc=auth,dc=internal,dc=aws,dc=testdrive,dc=openshift,dc=com)'}]
                     os_sdn_network_plugin_name=redhat/openshift-ovs-multitenant
-                    openshift_disable_check=memory_availability,disk_availability,docker_storage,package_version,docker_image_availability,package_availability
                     openshift_master_default_subdomain=apps.${AWS::AccountId}.${PublicHostedZone}
                     openshift_master_cluster_public_hostname=openshift.${AWS::AccountId}.${PublicHostedZone}
                     openshift_router_selector='region=infra'
                     openshift_registry_selector='region=infra'
+                    openshift_web_console_nodeselector={'region':'infra'}
+                    openshift_web_console_prefix='support.internal.aws.testdrive.openshift.com:5000/openshift3/ose-'
+
                     openshift_examples_modify_imagestreams=false
                     openshift_additional_repos=[{'id': 'openshift_packages', 'name': 'OpenShift_Packages', 'baseurl': 'http://master.internal.aws.testdrive.openshift.com/repo', 'enabled': 1, 'gpgcheck': 0}]
                     openshift_docker_insecure_registries=support.internal.aws.testdrive.openshift.com:5000
@@ -996,6 +1001,10 @@ Resources:
                     osm_etcd_image=support.internal.aws.testdrive.openshift.com:5000/rhel7/etcd
                     openshift_cli_image=support.internal.aws.testdrive.openshift.com:5000/openshift3/ose
                     osm_image=support.internal.aws.testdrive.openshift.com:5000/openshift3/ose
+                    openshift_release=v3.9.30
+                    openshift_image_tag=v3.9.30
+
+                    # special storage configs
                     openshift_storage_glusterfs_version=v3.9
                     openshift_storage_glusterfs_heketi_version=v3.9
                     openshift_storage_glusterfs_block_version=v3.9
@@ -1016,13 +1025,16 @@ Resources:
                     #cnsinfra_openshift_storage_glusterfs_registry_block_storageclass=true
                     #cnsinfra_openshift_storage_glusterfs_registry_block_host_vol_create=true
                     #cnsinfra_openshift_storage_glusterfs_registry_block_host_vol_size=30
+
+                    # metrics configs
                     openshift_metrics_install_metrics=false
-                    openshift_enable_service_catalog=false
                     #metrics_openshift_metrics_install_metrics=true
                     #metrics_openshift_metrics_cassandra_storage_type=dynamic
                     #metrics_openshift_metrics_cassandra_pvc_size=10Gi
                     #metrics_openshift_metrics_cassanda_pvc_storage_class_name=glusterfs-registry-block
                     #metrics_openshift_metrics_hawkular_hostname=metrics.apps.${AWS::AccountId}.${PublicHostedZone}
+
+                    # logging configs
                     openshift_logging_install_logging=false
                     #logging_openshift_logging_install_logging=true
                     #logging_openshift_logging_namespace=logging
@@ -1032,8 +1044,6 @@ Resources:
                     #logging_openshift_logging_es_memory_limit=2G
                     #logging_openshift_logging_kibana_hostname=kibana.apps.${AWS::AccountId}.${PublicHostedZone}
                     #logging_openshift_logging_public_master_url=https://kibana.apps.${AWS::AccountId}.${PublicHostedZone}
-                    openshift_web_console_nodeselector={'region':'infra'}
-                    openshift_web_console_prefix='support.internal.aws.testdrive.openshift.com:5000/openshift3/ose-'
                     openshift_hosted_prometheus_deploy=true
 
                     [etcd]

--- a/labguide/infra-mgmt-basics.adoc
+++ b/labguide/infra-mgmt-basics.adoc
@@ -855,13 +855,19 @@ Start the drain process like this:
 oc adm drain {{ NODE2_INTERNAL_FQDN }} --ignore-daemonsets
 ----
 
-After a few moments, all of the *Pods*, except those for Fluentd and Container
-Native Storage, previously running on `{{ NODE2_INTERNAL_FQDN }}` should have
-terminated and been launched elsewhere.
+After a few moments, all of the *Pods*, except those for Fluentd, Container
+Native Storage, and Prometheus previously running on `{{ NODE2_INTERNAL_FQDN
+}}` should have terminated and been launched elsewhere.
 
 ----
 oc get pods --all-namespaces -o wide
 ----
+
+[NOTE]
+====
+You can also use `oc adm manage-node` to list the pods on `{{
+NODE2_INTERNAL_FQDN }}` explicitly, if you like. 
+====
 
 The node `{{ NODE2_INTERNAL_FQDN }}` is now ready for an administrator to
 start maintenance operations. If those include a reboot of the system or

--- a/tests/run-module-6-infra-mgmt.yaml
+++ b/tests/run-module-6-infra-mgmt.yaml
@@ -501,25 +501,18 @@
         - networking
         - networking_test
 
-    - name: Make node03 unschedulable
-      command: oc adm manage-node node03.internal.aws.testdrive.openshift.com --schedulable=false
+    - name: Make node02 unschedulable
+      command: oc adm manage-node node02.internal.aws.testdrive.openshift.com --schedulable=false
       tags:
         - maintenance
 
-    - name: Evacuate node03
-      command: oc adm manage-node node03.internal.aws.testdrive.openshift.com --evacuate
+    - name: Drain node02
+      command: oc adm drain node02.internal.aws.testdrive.openshift.com --ignore-daemonsets
       tags:
         - maintenance
 
-    # instead of waiting like this, should probably find the gluster pod and then wait for it to be ready
-    - name: Wait 120 seconds for evacuation and restart
-      pause:
-        seconds: 120
-      tags:
-        - maintenance
-
-    - name: Make node03 schedulable again
-      command: oc adm manage-node node03.internal.aws.testdrive.openshift.com --schedulable=true
+    - name: Make node02 schedulable again
+      command: oc adm manage-node node02.internal.aws.testdrive.openshift.com --schedulable=true
       tags:
         - maintenance
 


### PR DESCRIPTION
The lab guide was already using drain, but the automation test was not.

Now the automation test drains node 2, just like the lab.

Tested and seemed to work. Could use one more test from someone else.