### PR TITLE
Quick installation does not exists ...

### DIFF
--- a/labguide/installation.adoc
+++ b/labguide/installation.adoc
@@ -16,7 +16,7 @@ started the lab.
 
 For more information on installing OpenShift Container Platform, please refer to
 the
-link:https://docs.openshift.com/container-platform/3.10/install_config/install/quick_install.html[installation
+link:https://docs.openshift.com/container-platform/3.10/install/index.html[installation
 section] of the product documentation.
 
 [NOTE]


### PR DESCRIPTION
… in 3.10 and is not recommended in 3.9 so I change the link.