### PR TITLE
oc volume is deprecated the command has been moved to "oc set volume"

### DIFF
--- a/labguide/app-mgmt-basics.adoc
+++ b/labguide/app-mgmt-basics.adoc
@@ -695,7 +695,7 @@ We will talk about this concept in more detail later. But let's imagine for a mo
 Here's how you would instruct OpenShift to create a *PersistentVolume* object, which represents external, persistent storage, and have it *mounted* inside the container's filesystem:
 
 ----
-oc volume dc/mapit --add --name=mapit-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=mapit-storage --mount-path=/app-storage
+oc set volume dc/mapit --add --name=mapit-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=mapit-storage --mount-path=/app-storage
 ----
 
 The output looks like this:

--- a/labguide/cns.adoc
+++ b/labguide/cns.adoc
@@ -782,11 +782,11 @@ The app is of course not usable like this. We can fix this by providing shared
 storage to this app.
 
 You can create a *PersistentVolumeClaim* and attach it into an application with
-the `oc volume` command. Execute the following
+the `oc set volume` command. Execute the following
 
 [source]
 ----
-oc volume dc/file-uploader --add --name=my-shared-storage \
+oc set volume dc/file-uploader --add --name=my-shared-storage \
 -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi \
 --claim-name=my-shared-storage --mount-path=/opt/app-root/src/uploaded
 ----
@@ -799,8 +799,8 @@ Like with the `mapit` application in "_Application Management Basics_" chapter, 
   `mount-path`
 * cause a new deployment of the application *Pods*
 
-For more information on what `oc volume` is capable of, look at its help output
-with `oc volume -h`. Now, let's look at the result of adding the volume:
+For more information on what `oc set volume` is capable of, look at its help output
+with `oc set volume -h`. Now, let's look at the result of adding the volume:
 
 ----
 oc get pvc

--- a/labguide/infra-mgmt-basics.adoc
+++ b/labguide/infra-mgmt-basics.adoc
@@ -927,11 +927,11 @@ oc login -u system:admin -n default
 ----
 
 Just like with the file uploader example, you can simply add a volume (and have
-its *PersistentVolumeClaim* created automatically) with the `oc volume` command.
+its *PersistentVolumeClaim* created automatically) with the `oc set volume` command.
 Execute the following:
 
 ----
-oc volume dc/docker-registry --add --name=registry-storage -t pvc \
+oc set volume dc/docker-registry --add --name=registry-storage -t pvc \
 --claim-mode=ReadWriteMany --claim-size=5Gi \
 --claim-name=registry-storage --claim-class={{ CNS_INFRA_STORAGECLASS }} --overwrite
 ----

--- a/tests/run-module-3-app-mgmt-basics.yaml
+++ b/tests/run-module-3-app-mgmt-basics.yaml
@@ -238,7 +238,7 @@
         - mapit-deploy
 
     - name: Add storage to mapit app
-      command: oc volume dc/mapit --add --name=mapit-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=mapit-storage --mount-path=/app-storage -n app-management
+      command: oc set volume dc/mapit --add --name=mapit-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=mapit-storage --mount-path=/app-storage -n app-management
       when:
         - mapit_dc.spec.template.spec.volumes is not defined
         - check_mapit_pvc is failed

--- a/tests/run-module-6-infra-mgmt.yaml
+++ b/tests/run-module-6-infra-mgmt.yaml
@@ -531,7 +531,7 @@
       shell: oc login -u system:admin -n default
 
     - name: update registry deployment
-      shell: oc volume dc/docker-registry --add --name=registry-storage -t pvc --claim-mode=ReadWriteMany --claim-size=10Gi --claim-class={{ cns_infra_storageclass }} --claim-name=registry-storage --overwrite
+      shell: oc set volume dc/docker-registry --add --name=registry-storage -t pvc --claim-mode=ReadWriteMany --claim-size=10Gi --claim-class={{ cns_infra_storageclass }} --claim-name=registry-storage --overwrite
 
     - name: wait for pvc to be bound
       shell: oc get pvc/registry-storage -o jsonpath='{$.status.phase}'

--- a/tests/run-module-7-cns.yaml
+++ b/tests/run-module-7-cns.yaml
@@ -213,7 +213,7 @@
       delay: 10
 
     - name: add pvc to app deploymentconfig
-      shell: oc volume dc/file-uploader --add --name=my-shared-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=my-shared-storage --mount-path=/opt/app-root/src/uploaded
+      shell: oc set volume dc/file-uploader --add --name=my-shared-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=my-shared-storage --mount-path=/opt/app-root/src/uploaded
 
     - name: wait for php app replication controller to be updated
       shell: oc get rc -o jsonpath='{$.items[?(@.spec.selector.deploymentconfig=="file-uploader")].spec.template.spec.volumes[?(@.persistentVolumeClaim.claimName=="my-shared-storage")].name}'


### PR DESCRIPTION
Updating the lab guides to replace `oc volume` with `oc set volume`

While I was working through the labs I received the following everytime I ran `oc volume`

`DEPRECATED: This command has been moved to "oc set volume"`