### PR TITLE
revert workshopper update

### DIFF
--- a/packer/roles/workshopper/files/workshopper.service
+++ b/packer/roles/workshopper/files/workshopper.service
@@ -5,7 +5,7 @@ Requires=docker.service
 
 [Service]
 EnvironmentFile=/etc/sysconfig/workshopper
-ExecStart=/usr/local/sbin/systemd-docker --env --cgroups name=systemd run --rm --name %n -p 80:8080 quay.io/osevg/workshopper@sha256:c40b92f5d257134807fd9ff1443ff2456c683e9126f7710524a5f28763375264
+ExecStart=/usr/local/sbin/systemd-docker --env --cgroups name=systemd run --rm --name %n -p 80:8080 docker.io/osevg/workshopper:0.2
 Restart=always
 RestartSec=10s
 Type=notify

--- a/packer/roles/workshopper/tasks/main.yml
+++ b/packer/roles/workshopper/tasks/main.yml
@@ -4,7 +4,7 @@
 
   - name: Pulling the workshopper docker image
     docker_image:
-      name: quay.io/osevg/workshopper@sha256:c40b92f5d257134807fd9ff1443ff2456c683e9126f7710524a5f28763375264
+      name: docker.io/osevg/workshopper:0.2
 
   - name: put the systemd-docker binary file at /usr/bin
     copy:


### PR DESCRIPTION
There's a bug in the latest workshopper (https://github.com/openshift-evangelists/workshopper/issues/64) that causes some of our vars not to render. Until it's fixed I'm reverting to 0.2