### PR TITLE
adding sudo to sed command (lab guide - template/limit/quota)

### DIFF
--- a/labguide/template-quota-limits.adoc
+++ b/labguide/template-quota-limits.adoc
@@ -260,7 +260,7 @@ This handy command will replace the default configuration (a blank entry of
 
 [source,bash,role="copypaste"]
 ----
-sed -i "s/projectRequestTemplate: ''/projectRequestTemplate: 'default\/project-request'/" /etc/origin/master/master-config.yaml
+sudo sed -i "s/projectRequestTemplate: ''/projectRequestTemplate: 'default\/project-request'/" /etc/origin/master/master-config.yaml
 ----
 
 #### Restart the Master


### PR DESCRIPTION
Editing master-config.yaml  - sed command fails without sudo - added sudo to the lab guide page for templates/limits/quota.