### PR TITLE
reworked overview, install, and app management labs

### DIFF
--- a/labguide/app-mgmt-basics.adoc
+++ b/labguide/app-mgmt-basics.adoc
@@ -5,8 +5,7 @@ application management on OpenShift Container Platform.
 
 [NOTE]
 ====
-You will want to have an SSH session opened to the `master` server for these
-lab exercises.
+You will still want to have an SSH session opened for these lab exercises.
 ====
 
 ### Core OpenShift Concepts
@@ -16,12 +15,14 @@ blocks will help you better see the big picture of application management on the
 platform.
 
 #### Projects
-A *Project* is a "bucket" of sorts. It's a meta construct where all of a user's
-resources live. From an administrative perspective, each *Project* can be
-thought of like a tenant. *Projects* may have multiple users who can access
-them, and users may be able to access multiple *Projects*.
+A *Project* is a "bucket" of sorts. It's a meta construct where all of a
+user's resources live. From an administrative perspective, each *Project* can
+be thought of like a tenant. *Projects* may have multiple users who can
+access them, and users may be able to access multiple *Projects*. Technically
+speaking, a user doesn't own the resources, the *Project* does. Deleting the
+user doesn't affect any of the created resources.
 
-For this exercise, first create a *Project* to hold our resources:
+For this exercise, first create a *Project* to hold some resources:
 
 [source,bash,role="copypaste"]
 ----
@@ -39,26 +40,26 @@ You will now launch a specific image that exists on Dockerhub
 
 [source,bash,role="copypaste"]
 ----
-oc new-app docker.io/siamaksade/mapit
+oc new-app quay.io/thoraxe/mapit
 ----
 
 The output will look like:
 
 ----
---> Found Docker image 9eca6ec (11 days old) from docker.io for "docker.io/siamaksade/mapit"
+--> Found Docker image 7ce7ade (20 months old) from quay.io for "quay.io/thoraxe/mapit"
 
-    * An image stream will be created as "mapit:latest" that will track this image
+    * An image stream tag will be created as "mapit:latest" that will track this image
     * This image will be deployed in deployment config "mapit"
     * Ports 8080/tcp, 8778/tcp, 9779/tcp will be load balanced by service "mapit"
       * Other containers can access this service through the hostname "mapit"
 
 --> Creating resources ...
-    imagestream "mapit" created
-    deploymentconfig "mapit" created
+    imagestream.image.openshift.io "mapit" created
+    deploymentconfig.apps.openshift.io "mapit" created
     service "mapit" created
 --> Success
     Application is not exposed. You can expose services to the outside world by executing one or more of the commands below:
-     'oc expose svc/mapit'
+     'oc expose svc/mapit' 
     Run 'oc status' to view your app.
 ----
 
@@ -92,55 +93,68 @@ oc get pods
 And you will see something like the following:
 
 ----
-NAME            READY     STATUS    RESTARTS   AGE
-mapit-1-6lczv   1/1       Running   0          3m
+NAME             READY   STATUS      RESTARTS   AGE
+mapit-1-5qmgw    1/1     Running     0          24s
+mapit-1-deploy   0/1     Completed   0          32s
 ----
 
 NOTE: Pod names are dynamically generated as part of the deployment process,
 which you will learn about shortly. Your name will be slightly different.
+
+NOTE: The `-deploy` pod is related to the `DeploymentConfig` which will be discussed later.
 
 The `describe` command will give you more information on the details of a pod.
 In the case of the pod name above:
 
 [source,bash,role="copypaste copypaste-warning"]
 ----
-oc describe pod mapit-1-6lczv
+oc describe pod mapit-1-5qmgw
 ----
 
 And you will see output similar to the following:
 
 ----
-Name:               mapit-1-r2sjj
+Name:               mapit-1-5qmgw
 Namespace:          app-management
 Priority:           0
 PriorityClassName:  <none>
-Node:               node02.internal.aws.testdrive.openshift.com/10.0.3.98
-Start Time:         Wed, 24 Oct 2018 17:17:38 +0000
+Node:               ip-10-0-139-135.ec2.internal/10.0.139.135
+Start Time:         Mon, 08 Apr 2019 19:38:55 +0000
 Labels:             app=mapit
                     deployment=mapit-1
                     deploymentconfig=mapit
-Annotations:        openshift.io/deployment-config.latest-version=1
-                    openshift.io/deployment-config.name=mapit
-                    openshift.io/deployment.name=mapit-1
-                    openshift.io/generated-by=OpenShiftNewApp
-                    openshift.io/scc=restricted
+Annotations:        k8s.v1.cni.cncf.io/networks-status:
+                      [{
+                          "name": "openshift-sdn",
+                          "interface": "eth0",
+                          "ips": [
+                              "10.128.4.13"
+                          ],
+                          "default": true,
+                          "dns": {}
+                      }]
+                    openshift.io/deployment-config.latest-version: 1
+                    openshift.io/deployment-config.name: mapit
+                    openshift.io/deployment.name: mapit-1
+                    openshift.io/generated-by: OpenShiftNewApp
+                    openshift.io/scc: restricted
 Status:             Running
-IP:                 10.129.0.2
+IP:                 10.128.4.13
 Controlled By:      ReplicationController/mapit-1
 Containers:
   mapit:
-    Container ID:   docker://b00a80b47411665930b5f2f08b6df76d49f40869a599500af99d073aac730654
-    Image:          docker.io/siamaksade/mapit@sha256:338a3031df6354e3adc3ba7d559ae22a0f2c79eade68aa72447f821cc7b8370c
-    Image ID:       docker-pullable://docker.io/siamaksade/mapit@sha256:338a3031df6354e3adc3ba7d559ae22a0f2c79eade68aa72447f821cc7b8370c
-    Ports:          8080/TCP, 8778/TCP, 9779/TCP
+    Container ID:   cri-o://77b0d785c73faf96d911b4fb7732f4f2f75666f9377e488b59bfee3fd6a5ede6
+    Image:          quay.io/thoraxe/mapit@sha256:8c7e0349b6a016e3436416f3c54debda4594ba09fd34b8a0dee0c4497102590d
+    Image ID:       quay.io/thoraxe/mapit@sha256:8c7e0349b6a016e3436416f3c54debda4594ba09fd34b8a0dee0c4497102590d
+    Ports:          9779/TCP, 8080/TCP, 8778/TCP
     Host Ports:     0/TCP, 0/TCP, 0/TCP
     State:          Running
-      Started:      Wed, 24 Oct 2018 17:17:42 +0000
+      Started:      Mon, 08 Apr 2019 19:39:13 +0000
     Ready:          True
     Restart Count:  0
     Environment:    <none>
     Mounts:
-      /var/run/secrets/kubernetes.io/serviceaccount from default-token-nh85v (ro)
+      /var/run/secrets/kubernetes.io/serviceaccount from default-token-nfwnb (ro)
 Conditions:
   Type              Status
   Initialized       True 
@@ -148,16 +162,22 @@ Conditions:
   ContainersReady   True 
   PodScheduled      True 
 Volumes:
-  default-token-nh85v:
+  default-token-nfwnb:
     Type:        Secret (a volume populated by a Secret)
-    SecretName:  default-token-nh85v
+    SecretName:  default-token-nfwnb
     Optional:    false
 QoS Class:       BestEffort
-Node-Selectors:  node-role.kubernetes.io/compute=true
-Tolerations:     <none>
+Node-Selectors:  <none>
+Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
+                 node.kubernetes.io/unreachable:NoExecute for 300s
 Events:
-
-...
+  Type    Reason     Age    From                                   Message
+  ----    ------     ----   ----                                   -------
+  Normal  Scheduled  2m16s  default-scheduler                      Successfully assigned app-management/mapit-1-5qmgw to ip-10-0-139-135.ec2.internal
+  Normal  Pulling    2m7s   kubelet, ip-10-0-139-135.ec2.internal  Pulling image "quay.io/thoraxe/mapit@sha256:8c7e0349b6a016e3436416f3c54debda4594ba09fd34b8a0dee0c4497102590d"
+  Normal  Pulled     118s   kubelet, ip-10-0-139-135.ec2.internal  Successfully pulled image "quay.io/thoraxe/mapit@sha256:8c7e0349b6a016e3436416f3c54debda4594ba09fd34b8a0dee0c4497102590d"
+  Normal  Created    118s   kubelet, ip-10-0-139-135.ec2.internal  Created container mapit
+  Normal  Started    118s   kubelet, ip-10-0-139-135.ec2.internal  Started container mapit
 ----
 
 This is a more detailed description of the pod that is running. You can see what
@@ -177,10 +197,11 @@ them as endpoints to the *Service*, and the incoming requests would not notice
 anything different except that the *Service* was now doing a better job handling
 the requests.
 
-When you asked OpenShift to run the image, it automatically created a *Service*
-for you. Remember that services are an internal construct. They are not
-available to the "outside world", or anything that is outside the OpenShift
-environment. That's OK, as you will learn later.
+When you asked OpenShift to run the image, the `new-app` command
+automatically created a *Service* for you. Remember that services are an
+internal construct. They are not available to the "outside world", or
+anything that is outside the OpenShift environment. That's OK, as you will
+learn later.
 
 The way that a *Service* maps to a set of *Pods* is via a system of *Labels* and
 *Selectors*. *Services* are assigned a fixed IP address and many ports and
@@ -190,8 +211,7 @@ There is a lot more information about
 https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/pods_and_services.html#services[Services],
 including the YAML format to make one by hand, in the official documentation.
 
-The `new-app` command used earlier caused a service to be created. You can see
-the current list of services in a project with:
+You can see the current list of services in a project with:
 
 [source,bash,role="copypaste"]
 ----
@@ -223,19 +243,19 @@ You will see something like the following:
 Name:              mapit
 Namespace:         app-management
 Labels:            app=mapit
-Annotations:       openshift.io/generated-by=OpenShiftNewApp
+Annotations:       openshift.io/generated-by: OpenShiftNewApp
 Selector:          app=mapit,deploymentconfig=mapit
 Type:              ClusterIP
-IP:                172.30.48.204
+IP:                172.30.1.208
 Port:              8080-tcp  8080/TCP
 TargetPort:        8080/TCP
-Endpoints:         10.129.0.2:8080
+Endpoints:         10.128.4.13:8080
 Port:              8778-tcp  8778/TCP
 TargetPort:        8778/TCP
-Endpoints:         10.129.0.2:8778
+Endpoints:         10.128.4.13:8778
 Port:              9779-tcp  9779/TCP
 TargetPort:        9779/TCP
-Endpoints:         10.129.0.2:9779
+Endpoints:         10.128.4.13:9779
 Session Affinity:  None
 Events:            <none>
 ----
@@ -259,16 +279,16 @@ kind: Service
 metadata:
   annotations:
     openshift.io/generated-by: OpenShiftNewApp
-  creationTimestamp: 2018-10-24T17:17:35Z
+  creationTimestamp: 2019-04-08T19:38:45Z
   labels:
     app: mapit
   name: mapit
   namespace: app-management
-  resourceVersion: "19394"
+  resourceVersion: "189058"
   selfLink: /api/v1/namespaces/app-management/services/mapit
-  uid: b2e86550-d7b0-11e8-bb81-02f850fb3182
+  uid: ec6ab96f-5a35-11e9-97f0-0a1014b36356
 spec:
-  clusterIP: 172.30.48.204
+  clusterIP: 172.30.1.208
   ports:
   - name: 8080-tcp
     port: 8080
@@ -289,7 +309,6 @@ spec:
   type: ClusterIP
 status:
   loadBalancer: {}
-
 ----
 
 Take note of the `selector` stanza. Remember it.
@@ -300,7 +319,7 @@ then execute the following:
 
 [source,bash,role="copypaste copypaste-warning"]
 ----
-oc get pod mapit-1-6lczv -o yaml
+oc get pod mapit-1-5qmgw -o yaml
 ----
 
 Under the `metadata` section you should see the following:
@@ -310,7 +329,7 @@ Under the `metadata` section you should see the following:
     app: mapit
     deployment: mapit-1
     deploymentconfig: mapit
-  name: mapit-1-6lczv
+  name: mapit-1-5qmgw
 ----
 
 * The *Service* has `selector` stanza that refers to `app: mapit` and
@@ -556,13 +575,20 @@ extension, your *Pods*) to be accessible to the outside world, then you need to
 create a *Route*.
 
 Do you remember setting up the router? You probably don't. That's because the
-installer settings created a router for you! The router lives in the `default`
+installation deployed an Operator for the router, and the operator created a
+router for you! The router lives in the `openshift-ingress`
 *Project*, and you can see information about it with the following command:
 
 [source,bash,role="copypaste"]
 ----
-oc describe dc router -n default
+oc describe deployment router-default -n openshift-ingress
 ----
+
+NOTE: A *Deployment* is a Kubernetes native object, whereas a
+*DeploymentConfig* is an OpenShift-specific object with a few extra features,
+namely around `triggers` and what caues new deployments to take place.
+
+You will explore the Operator for the router more in a subsequent exercise.
 
 #### Creating a Route
 Creating a *Route* is a pretty straight-forward process.  You simply `expose`
@@ -591,8 +617,8 @@ oc get route
 You will see something like:
 
 ----
-NAME      HOST/PORT                                                            PATH      SERVICES   PORT       TERMINATION   WILDCARD
-mapit     mapit-app-management.{{OCP_ROUTING_SUFFIX}}             mapit      8080-tcp                 None
+NAME    HOST/PORT                                                           PATH   SERVICES   PORT       TERMINATION   WILDCARD
+mapit   mapit-app-management.apps.cluster-GUID.GUID.openshiftworkshop.com          mapit      8080-tcp
 ----
 
 If you take a look at the `HOST/PORT` column, you'll see a familiar looking
@@ -601,17 +627,15 @@ hostname:
 
 `{SERVICENAME}-{PROJECTNAME}.{ROUTINGSUBDOMAIN}`
 
-How does this work? Firstly, the `ROUTINGSUBDOMAIN` can be configured at install
-time. We did this for you. In the `/etc/ansible/hosts` file you will find the
-following line:
+In the subsequent router Operator labs we'll explore this and other
+configuration options.
 
-----
-openshift_master_default_subdomain={{OCP_ROUTING_SUFFIX}}
-----
-
-There is also a wildcard DNS entry that points `+*.apps...+` to the host where the
-router lives. OpenShift concatenates the *Service* name, *Project* name, and the
-routing subdomain to create this FQDN/URL.
+While the router configuration specifies the domain(s) that the router should
+listen for, something still needs to get requests for those domains to the
+Router in the first place. There is a wildcard DNS entry that points
+`+*.apps...+` to the host where the router lives. OpenShift concatenates the
+*Service* name, *Project* name, and the routing subdomain to create this
+FQDN/URL.
 
 You can visit this URL using your browser, or using `curl`, or any other tool.
 It should be accessible from anywhere on the internet.
@@ -674,7 +698,7 @@ test it using `curl`:
 
 [source,bash,role="copypaste"]
 ----
-curl mapit-app-management.{{OCP_ROUTING_SUFFIX}}/health
+curl mapit-app-management.apps.cluster-$GUID.$GUID.openshiftworkshop.com/health
 ----
 
 You will get some JSON as a response:
@@ -703,14 +727,15 @@ You will see a section like:
 
 ----
 ...
- Containers:
+  Containers:
    mapit:
-    Image:                      docker.io/siamaksade/mapit@sha256:338a3031df6354e3adc3ba7d559ae22a0f2c79eade68aa72447f821cc7b8370c
-    Ports:                      8080/TCP, 8778/TCP, 9779/TCP
-    Liveness:                   http-get http://:8080/health delay=30s timeout=1s period=10s #success=1 #failure=3
-    Volume Mounts:              <none>
-    Environment Variables:      <none>
-  No volumes.
+    Image:		quay.io/thoraxe/mapit@sha256:8c7e0349b6a016e3436416f3c54debda4594ba09fd34b8a0dee0c4497102590d
+    Ports:		9779/TCP, 8080/TCP, 8778/TCP
+    Host Ports:		0/TCP, 0/TCP, 0/TCP
+    Liveness:		http-get http://:8080/health delay=30s timeout=1s period=10s #success=1 #failure=3
+    Environment:	<none>
+    Mounts:		<none>
+  Volumes:		<none>
 ...
 ----
 
@@ -721,155 +746,64 @@ Similarly, you can set a readiness probe in the same manner:
 oc set probe dc/mapit --readiness --get-url=http://:8080/health --initial-delay-seconds=30
 ----
 
-### Add Storage to the Application
+### Examining DeploymentConfigs and ReplicationControllers
 
-The `mapit` application currently doesn't leverage any persistent storage. If the pod dies, so does all the content inside the container.
-
-[NOTE]
-====
-The directories that make up the containers internal filesystem are a blend of the read-only layers of the container image and the top-most writable layer that is added as soon as a container instance is started from the image.
-The writable layer is disposed of once the container is deleted which happens regularly in a container orchestration environment.
-====
-
-If a pod in OpenShift needs reliable storage, for example to host a database, we would need to supply a **persistent** volume to the pod. This type of storage outlives the container, i.e. it persists when the pod dies. It typically comes from an external storage system.
-
-We will talk about this concept in more detail later. But let's imagine for a moment, the `mapit` application needs persistent storage available under the `/app-storage` directory inside the container.
-
-Here's how you would instruct OpenShift to create a *PersistentVolume* object, which represents external, persistent storage, and have it *mounted* inside the container's filesystem:
-
-[source,bash,role="copypaste"]
-----
-oc set volume dc/mapit --add --name=mapit-storage -t pvc --claim-mode=ReadWriteMany --claim-size=1Gi --claim-name=mapit-storage --mount-path=/app-storage
-----
-
-The output looks like this:
-
-----
-deploymentconfig.apps.openshift.io/mapit volume updated
-----
-
-In the first step a *PersistentVolumeClaim* was created. This object represents a request for storage of a certain kind, with a certain capacity from the user to OpenShift.
-Next the `DeploymentConfig` of `mapit` is updated to reference this storage and make it available under the `/app-storage` directory inside the pod.
-
-You can see the new `DeploymentConfig` like this:
-
-[source,bash,role="copypaste"]
-----
-oc get dc mapit
-----
-
-The output will show that a new revision was created as part of the update with storage.
-
-----
-NAME      REVISION   DESIRED   CURRENT   TRIGGERED BY
-mapit     4          1         1         config,image(mapit:latest)
-----
-
-Likely, depending when you ran the command you may or may not see that the new pod is still being spawned:
-
-[source,bash,role="copypaste"]
-----
-oc get pod
-----
-
-----
-NAME             READY     STATUS              RESTARTS   AGE
-mapit-3-ntd9w    1/1       Running             0          9m
-mapit-4-d872b    0/1       ContainerCreating   0          5s
-mapit-4-deploy   1/1       Running             0          10s
-----
-
-We will look at how this storage was provisioned automatically in the background using _Red Hat OpenShift Container Storage_ later. You will also learn how to request storage as part of a template.
-
-Suffice it to say, a 1GiB GlusterFS volume has been created and made available to the pod.
-
-Log on to the new pod (**your pod names will be different**) using the remote-shell capability of the `oc` client:
-
-[source,none,role="copypaste copypaste-warning"]
-----
-oc rsh mapit-4-d872b
-----
-
-*Being in the container's shell session*, list the content of the root directory from the perspective of the container's namespace:
-
-[source,bash,role="copypaste"]
-----
-ls -ahl /
-----
-
-You will see an additional directory there under `/app-storage`
-
-----
-total 36K
-drwxr-xr-x.  19 root  root 4.0K Apr  9 11:00 .
-drwxr-xr-x.  19 root  root 4.0K Apr  9 11:00 ..
--rwxr-xr-x.   1 root  root    0 Apr  9 11:00 .dockerenv
--rw-r--r--.   1 root  root  16K Dec 14  2016 anaconda-post.log
-drwxrwsr-x.   4 root  2000 4.0K Apr  9 11:05 app-storage <1>
-lrwxrwxrwx.   1 root  root    7 Dec 14  2016 bin -> usr/bin
-drwxrwxrwx.   2 jboss root  137 Aug  4  2017 deployments
-drwxr-xr-x.   5 root  root  360 Apr  9 11:00 dev
-drwxr-xr-x.  52 root  root 4.0K Apr  9 11:00 etc
-drwxr-xr-x.   2 root  root    6 Nov  5  2016 home
-lrwxrwxrwx.   1 root  root    7 Dec 14  2016 lib -> usr/lib
-lrwxrwxrwx.   1 root  root    9 Dec 14  2016 lib64 -> usr/lib64
-drwx------.   2 root  root    6 Dec 14  2016 lost+found
-drwxr-xr-x.   2 root  root    6 Nov  5  2016 media
-drwxr-xr-x.   2 root  root    6 Nov  5  2016 mnt
-drwxr-xr-x.   4 root  root   61 Jan 18  2017 opt
-dr-xr-xr-x. 299 root  root    0 Apr  9 11:00 proc
-dr-xr-x---.   2 root  root  114 Dec 14  2016 root
-drwxr-xr-x.  11 root  root  145 Apr  9 11:00 run
-lrwxrwxrwx.   1 root  root    8 Dec 14  2016 sbin -> usr/sbin
-drwxr-xr-x.   2 root  root    6 Nov  5  2016 srv
-dr-xr-xr-x.  13 root  root    0 Apr  9 09:14 sys
-drwxrwxrwt.  10 root  root  241 Apr  9 11:00 tmp
-drwxr-xr-x.  13 root  root  155 Dec 16  2016 usr
-drwxr-xr-x.  18 root  root  238 Dec 14  2016 var
-----
-<1> This is where the persistent storage appears inside the container
-
-One of the interesting aspects of persistent storage from GlusterFS is that it is actually "shared" as indicated by the claim mode **ReadWriteMany**. This means that multiple containers can read and write to the same storage location concurrently.
-
-Let's try this. First write a file to the persistent, shared storage and then exit the remote shell session.
-
-[source,bash,role="copypaste"]
-----
-echo "Hello World from OpenShift" > /app-storage/hello.txt
-exit
-----
-
-Now, let's scale your deployment to two pods:
-
-[source,bash,role="copypaste"]
-----
-oc scale --replicas=2 dc/mapit
-----
-
-After some time, ensure both are in the `Running` state:
+Execute the following:
 
 [source,bash,role="copypaste"]
 ----
 oc get pods
 ----
 
-----
-NAME            READY     STATUS    RESTARTS   AGE
-mapit-4-ljjmf   1/1       Running   0          24m
-mapit-4-d872b   1/1       Running   0          25m
-----
-
-Read the text file from the other pod using the `cat` command appended directly to the `oc rsh` call:
-
-[source,none,role="copypaste copypaste-warning"]
-----
-oc rsh mapit-4-ljjmf cat /app-storage/hello.txt
-----
-
-You should see the content of the file from **the other pod**:
+You should see something like:
 
 ----
-Hello World from OpenShift
+NAME             READY   STATUS      RESTARTS   AGE
+mapit-1-deploy   0/1     Completed   0          18h
+mapit-2-deploy   0/1     Completed   0          112s
+mapit-3-deploy   0/1     Completed   0          75s
+mapit-3-kkwxq    1/1     Running     0          66s
 ----
 
-This illustrates how to provide persistent storage, that is independent from the pod lifecycle and can optionally be shared by multiple pods at the same time.
+Notice that there are 3 `-deploy` pods? And that the name of the current `mapit` pod has the number 3 in it? This is because each change to the *DeploymentConfig* counted as a _configuration_ change, which _triggered_ a new _deployment_. The `-deploy` pod is responsible for ensuring the new deployment happens.
+
+Execute the following:
+
+[source,bash,role="copypaste"]
+----
+oc get deploymentconfigs
+----
+
+You should see something like:
+
+----
+NAME    REVISION   DESIRED   CURRENT   TRIGGERED BY
+mapit   3          1         1         config,image(mapit:latest)
+----
+
+You made two material configuration changes after the initial deployment,
+thus you are now on the third revision of the *DeploymentConfiguration*.
+
+Execute the following:
+
+[source,bash,role="copypaste"]
+----
+oc get replicationcontrollers
+----
+
+You should see something like:
+
+----
+NAME      DESIRED   CURRENT   READY   AGE
+mapit-1   0         0         0       18h
+mapit-2   0         0         0       5m14s
+mapit-3   1         1         1       4m37s
+----
+
+Each time a new deployment is triggered, the deployer pod creates a new
+*ReplicationController* which then is responsible for ensuring that pods
+exist. Notice that the old RCs have a desired scale of zero, and the most
+recent RC has a desired scale of 1.
+
+If you `oc describe` each of these RCs you will see how `-1` has no probes,
+and then `-2` and `-3` have the new probes, respectively.

--- a/labguide/environment.adoc
+++ b/labguide/environment.adoc
@@ -1,52 +1,18 @@
-OpenShift Container## Environment Overview
+## Environment Overview
 
-You will be interacting with an OpenShift 3.11 cluster that is running on {{
-ENVIRONMENT }}. During the lab you will also install OpenShift Container Storage
-3.11. The complete environment consists of the following systems:
+You will be interacting with an OpenShift 4 cluster that is running on {{ ENVIRONMENT }}. During the lab you will also install OpenShift Container
+Storage, based on Rook/Ceph.
 
-* 1 master node
-* 1 infrastructure node
-* 6 "application" nodes
-** 3 will run workload and the initial Container Native Storage instances
-** 3 will be added to the cluster later
-* 1 server running Red Hat Identity Management (IdM, for LDAP authentication)
+The basics of the OpenShift 4 installation have been completed in advanced.
+The OpenShift cluster is essentially set to all defaults and looks like the
+following:
 
-.Lab Environment Overview
-[options="header"]
-|==============================================
-| Role     | Internal FQDN
-| Master Node       | {{MASTER_INTERNAL_FQDN}}
-| Infrastructure Node        | {{INFRA_INTERNAL_FQDN}}
-| Application Node #1        | {{NODE1_INTERNAL_FQDN}}
-| Application Node #2        | {{NODE2_INTERNAL_FQDN}}
-| Application Node #3        | {{NODE3_INTERNAL_FQDN}}
-| Application Node #4        | {{NODE4_INTERNAL_FQDN}}
-| Application Node #5        | {{NODE5_INTERNAL_FQDN}}
-| Application Node #6        | {{NODE6_INTERNAL_FQDN}}
-| IdM Server     |    {{IDM_INTERNAL_FQDN}}
-|==============================================
+* 3 master nodes
+* 3 worker nodes
 
-All addresses are internal to the lab environment. The only system you
-publicly access via SSH and the browser is the OpenShift Master node:
-
-.Public Lab Access
-[options="header"]
-|==============================================
-| Role     | Public FQDN
-| Master Node       | {{MASTER_EXTERNAL_FQDN}}
-|==============================================
-
-You will be installing OpenShift Container Platform v3.11 using the advanced
-installation method, which involves executing various Ansible playbooks. You
-will also install Container Native Storage v3.11.
-
-Note that references to product documentation will be specifically pointing
-to the 3.11 versions, but newer software and documentation versions may be
-available.
-
-## How to get support
-
-In case of technical or functional problems please reach out to mailto:openshift-ops-testdrive@redhat.com[openshift-ops-testdrive@redhat.com]. This is a ticket based system where you will be able to reach the authors and supporters of this Test Drive Experience.
+Additionally, this lab guide is being hosted on an EC2 instance that you will
+now SSH into in order to access the environment and complete the rest of the
+exercises.
 
 ## Conventions
 You will see various code and command blocks throughout these exercises. Some of
@@ -59,28 +25,26 @@ of the command before execution. If you see a command block with a red border
 some command to modify
 ----
 
-Most command blocks support auto highlighting with a click. If you hover over the command block above and click, it should automatically highlight all the text to make for easier copying.
+Most command blocks support auto highlighting with a click. If you hover over
+the command block above and left-click, it should automatically highlight all the
+text to make for easier copying.
 
 ### Logging in
-Most of the exercises in this lab will be facilitated using the OpenShift command line client on the master node. For convenient access to the master's command line we provide a web-based SSH console: {{ SSH_CONSOLE_URL }}
-
-Use the user name `cloud-user` and the password `{{ KEYNAME }}` when prompted.
-
-.SSH Console Login
-image::webssh_login.png[]
-
-If you prefer to use an SSH client on your system you can do that too, using the same credentials:
+The bastion host on which this lab guide is running is currently configured
+with an SSH key that is also present on the machine where you are sitting.
+You can simply SSH to the bastion host like so:
 
 [source,bash,role="copypaste"]
 ----
-ssh -l cloud-user {{MASTER_EXTERNAL_FQDN}}
+ssh -l lab-user {{ MASTER_EXTERNAL_FQDN }}
 ----
 
-Once you are logged in you end up on the OpenShift Master Node:
+The `lab-user` account has password-less sudo privileges. You'll notice that
+there is a 4-digit alphanumeric string (eg: f4a3) in the hostname. This
+string is your `GUID`. Since you will often use GUID, it makes sense to
+export it as an environment variable:
 
+[source,bash,role="copypaste"]
 ----
-[cloud-user@master ~]$
+export GUID=`hostname | cut -d. -f2`
 ----
-
-The `cloud-user` account has password-less sudo privileges and SSH login on
-all systems using internal addressing from the table above.

--- a/labguide/installation.adoc
+++ b/labguide/installation.adoc
@@ -1,28 +1,19 @@
 ## Installation and Verification
 
-The primary method of installing OpenShift Container Platform is based on
-Ansible playbooks. These playbooks ship as part of the product in the
-`openshift-ansible` package.
+The scope of the new installer-provisioned infrastructure (IPI) OpenShift 4
+installation is purposefully narrow. It is designed for simplicity and
+ensured success. Many of the items and configurations that were previously
+handled by the installer are now expected to be "Day 2" operations, performed
+just after the installation of the control plane and basic workers completes.
+The installer provides a guided experience for provisioning the cluster on a
+particular platform.
 
-This method has, in the past, been referred to as the `advanced installation
-method` and it involves Ansible directly running the installation playbooks.
-The advanced installer supports many configuration and customization options.
-It also covers installation of supporting infrastructure like
-OpenShift Container storage, logging and metrics components.
-
-Your environment comes with a preinstalled cluster that has been deployed
-using the installer's configuration file (`/etc/ansible/hosts`) when you
-started the lab.
-
-For more information on installing OpenShift Container Platform, please refer to
-the
-link:https://docs.openshift.com/container-platform/3.11/install/index.html[installation
-section] of the product documentation.
+This IPI installation has already been performed for you, and the cluster is
+in its basic, default state.
 
 [NOTE]
 ====
-At this point you should be logged in as `cloud-user` on the OpenShift Master
-node via SSH.
+At this point you should be logged in as `lab-user` on the bastion via SSH.
 ====
 
 ### Master Components
@@ -78,91 +69,123 @@ For more information on the OpenShift Master's areas of responsibility, please r
 the
 link:https://docs.openshift.com/container-platform/3.11/architecture/infrastructure_components/kubernetes_infrastructure.html[infrastructure components section] of the product documentation.
 
-### Examining the provided Ansible inventory file
-First, let's examine the provided installer configuration file.
+### Examining the installation artifacts
+OpenShift 4 installs with two effective superusers:
 
-#### Look at the file
-Use `cat`, `less`, or an editor to look at the `/etc/ansible/hosts` file:
+* `kubeadmin` (technically an alias for `kube:admin`)
+* `system:admin`
 
-[source,bash,role="copypaste"]
-----
-cat /etc/ansible/hosts
-----
+Why two? Because `system:admin` is a user that uses a certificate to login
+and has no password. Therefore this superuser cannot log-in to the web
+console (which requires a password).
 
-General settings and other variable information is defined on lines within the
-`[OSEv3:vars]` section. There are also various host groups defined for things
-like *Masters* and *Nodes*.
-
-For more details on how OpenShift uses Ansible for its installation, please
-refer to the
-link:https://docs.openshift.com/container-platform/3.11/install/configuring_inventory_file.html[Configuring Your Inventory File].
-
-The top-level playbook in
-`/usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml` triggers
-the installation of the cluster and all of it's components. It's idempotent,
-which means you can execute this playbook multiple times without harm. This
-also allows you to deploy additional components after the initial install by
-simply modifying the configuration in `/etc/ansible/hosts` and re-run the
-installer.
-
-In addition to this, there are playbooks that only deploy a specific
-component or service, which makes them faster to execute.
-
-[TIP]
-====
-A typical multi-host installation like this might normally take around an
-hour depending on the speed of your internet connection. Disconnected
-installation options are also available. Prerequisites and other information
-is all covered in the documentation.
-====
+If you want additional users to be able to authenticate to and use the
+cluster, you need to configure your desired authentication mechanisms using
+CustomResources and Operators as previously discussed. LDAP-based
+authentication will be configured as one of the lab exercises.
 
 ### Verifying the Installation
 Let's do some basic tests with your installation. As an administrator, most
 of your interaction with OpenShift will be from the command line. The `oc`
 program is a command line interface that talks to the OpenShift API.
 
-During the OpenShift installation, the `root` system account on the `master`
-host is configured to use a special OpenShift "super administrator" account.
-Because of this, it is vitally important that you protect access to the
-`root` system account, or remove this preconfigured config. Otherwise, anyone
-who can `sudo` on the master has super user privileges on the entire cluster.
-
-#### Login on the master
-Additionally, your Linux system account on the master, `cloud-user`, is
-preconfigured to access this OpenShift "super administrator" without a
-password. Type the following command to login as the internal super-user on
-OpenShift:
+As the `lab-user`:
 
 [source,bash,role="copypaste"]
 ----
-oc login -u system:admin
+sudo su - ec2-user
 ----
 
-You will see that you got logged in to a project called 'default'. More on
-projects later.
+#### Login to OpenShift
+When the installation completed, the installer left some artifacts that
+contain the various URLs and passwords required to access the environment.
+The installation program was run under the `ec2-user` account, so, first, you
+need to get to it. 
+
+[source,bash,role="copypaste"]
+----
+cd ~/cluster-$GUID
+ls -al
+----
+
+You'll see something like the following:
 
 ----
-Logged into "https://master.internal.aws.testdrive.openshift.com:443" as "system:admin" using existing credentials.
-
-You have access to the following projects and can switch between them with 'oc project <projectname>':
-
-  * default
-    kube-public
-    kube-system
-    management-infra
-    openshift
-    openshift-console
-    openshift-infra
-    openshift-logging
-    openshift-metrics
-    openshift-monitoring
-    openshift-node
-    openshift-sdn
-    openshift-web-console
-    storage
-
-Using project "default".
+total 3544
+drwxrwxr-x. 4 ec2-user ec2-user     199 Apr  8 14:43 .
+drwx------. 7 ec2-user ec2-user     205 Apr  8 15:10 ..
+drwxr-xr-x. 2 ec2-user ec2-user      50 Apr  8 14:30 auth
+-rw-r--r--. 1 ec2-user ec2-user     271 Apr  8 14:24 metadata.json
+-rw-rw-r--. 1 ec2-user ec2-user  625865 Apr  8 14:49 .openshift_install.log
+-rw-r--r--. 1 ec2-user ec2-user 2460298 Apr  8 14:30 .openshift_install_state.json
+-rw-r--r--. 1 ec2-user ec2-user     676 Apr  8 14:24 terraform.aws.auto.tfvars
+-rw-rw-r--. 1 ec2-user ec2-user  208531 Apr  8 14:43 terraform.tfstate
+-rw-r--r--. 1 ec2-user ec2-user  322023 Apr  8 14:24 terraform.tfvars
+drwxr-xr-x. 2 ec2-user ec2-user      62 Apr  8 14:24 tls
 ----
+
+The OpenShift 4 IPI installation embeds Terraform in order to create some of
+the cloud provider resources. You can see some of its outputs here. The
+important file right now is the `.openshift_install.log`. Its last few lines
+contain the relevant output to figure out how to access your environment:
+
+[source,bash,role="copypaste"]
+----
+tail -n5 .openshift_install.log
+----
+
+You will see something like the following::
+
+----
+time="2019-04-08T14:49:34Z" level=info msg="Install complete!"
+time="2019-04-08T14:49:34Z" level=info msg="Run 'export KUBECONFIG=/home/ec2-user/cluster-f4a3/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI."
+time="2019-04-08T14:49:34Z" level=info msg="The cluster is ready when 'oc login -u kubeadmin -p SxUr2-tQ2py-c6jq2-YtjW3' succeeds (wait a few minutes)."
+time="2019-04-08T14:49:34Z" level=info msg="Access the OpenShift web-console here: https://console-openshift-console.apps.cluster-f4a3.f4a3.openshiftworkshop.com"
+time="2019-04-08T14:49:34Z" level=info msg="Login to the console with user: kubeadmin, password: SxUr2-tQ2py-c6jq2-YtjW3"
+----
+
+Take note of your web console URL and the `kubeadmin` password. The installer
+has fortunately also given you a convenient `export` command to run:
+
+[source,bash,role="copypaste"]
+----
+export KUBECONFIG=/home/ec2-user/cluster-$GUID/auth/kubeconfig
+----
+
+The `oc` tool should already be in your path and be executable.
+
+#### Examine the Cluster Version
+First, you can check the current version of your OpenShift cluster by
+executing the following:
+
+[source,bash,role="copypaste"]
+----
+oc get clusterversion
+----
+
+And you will see some output like:
+
+```
+NAME      VERSION     AVAILABLE   PROGRESSING   SINCE   STATUS
+version   4.0.0-0.9   True        False         173m    Cluster version is 4.0.0-0.9
+```
+
+For more details, you can use `oc describe clusterversion`:
+
+```
+Name:         version
+Namespace:    
+Labels:       <none>
+Annotations:  <none>
+API Version:  config.openshift.io/v1
+Kind:         ClusterVersion
+Metadata:
+...
+    Version:            4.0.0-0.9
+  Observed Generation:  1
+  Version Hash:         -XUey1xSiwE=
+Events:                 <none>
+```
 
 #### Look at the Nodes
 Execute the following command to see a list of the *Nodes* that OpenShift knows
@@ -176,290 +199,39 @@ oc get nodes
 The output should look something like the following:
 
 ----
-NAME                                          STATUS    ROLES     AGE	VERSION
-{{ INFRA_INTERNAL_FQDN }}    Ready     infra     1m	v1.11.0+d4cacc0
-{{ MASTER_INTERNAL_FQDN }}   Ready     master    1m	v1.11.0+d4cacc0
-{{ NODE1_INTERNAL_FQDN }}   Ready     compute   1m	v1.11.0+d4cacc0
-{{ NODE2_INTERNAL_FQDN }}   Ready     compute   1m	v1.11.0+d4cacc0
-{{ NODE3_INTERNAL_FQDN }}   Ready     compute   1m	v1.11.0+d4cacc0
+NAME                           STATUS   ROLES          AGE    VERSION
+ip-10-0-129-33.ec2.internal    Ready    master         3h5m   v1.12.4+509916ce1
+ip-10-0-139-97.ec2.internal    Ready    worker         178m   v1.12.4+509916ce1
+ip-10-0-144-15.ec2.internal    Ready    master         3h5m   v1.12.4+509916ce1
+ip-10-0-157-196.ec2.internal   Ready    worker         177m   v1.12.4+509916ce1
+ip-10-0-164-163.ec2.internal   Ready    master         3h5m   v1.12.4+509916ce1
+ip-10-0-175-100.ec2.internal   Ready    worker         178m   v1.12.4+509916ce1
+
 ----
 
-All of the systems listed in the `[nodes]` group in the `/etc/ansible/hosts`
-file should be listed here. 1 Infrastructure Node, 1 Master and 3 Worker nodes.
-
-The OpenShift *Master* is also a *Node* because it needs to participate in the
-software defined network (SDN).
-The *Infra* node will only run workloads related to supporting OpenShift infrastructure.
+You have 3 masters and 3 workers. The OpenShift *Master* is also a *Node*
+because it needs to participate in the software defined network (SDN). If you
+need additional nodes for additional purposes, you can create them very
+easily when using IPI and leveraging the cloud provider operators. You will
+create nodes to run OpenShift infrastructure components (registry, router,
+etc.) in one of the exercises.
 
 #### Check the Web Console
-OpenShift provides a web console for users, developers and application operators
-to interact with the environment. There aren't many cluster administrative
-functions to perform through the web console. Some OpenShift components (like
-the internal image registry) run on top of the OpenShift environment,
-and you can see these things. However, we have not yet explored authentication
-topics, so you have no cluster administrator "human" accounts yet.
+OpenShift provides a web console for users, developers, application
+operators, and administrators to interact with the environment. Many of the
+cluster administration functions, including upgrading the cluster itself, can
+be performed simply using the web console.
 
-Point your browser to {{WEB_CONSOLE_URL}} to verify that the web console is
-available and responding. You can login using the user `teamuser1` with password `openshift`.
-You are not required to do anything in the web console at this point.
+The web console actually runs as an application inside the OpenShift
+environment and is exposed via the OpenShift Router. You will learn more
+about the router in a subsequent exercise. For now, you can simply click the
+link in the `tail` output above and then login to the web console with the
+`kubeadmin` user and the supplied password.
 
-WARNING: You will receive a self-signed certificate error in your browser. When
-OpenShift is installed, by default, a CA and SSL certificates are generated for
-all inter-component communication within OpenShift, including the web console.
-It is possible to provide your own SSL certificates during the installation, and
-more information can be found in the
-link:https://docs.openshift.com/container-platform/3.11/install_config/certificate_customization.html#ansible-configuring-custom-certificates[custom
-certificates] section of the installation documentation.
-
-#### Prometheus
-OpenShift is currently in the process of adopting Prometheus for cluster
-infrastructure monitoring and alerting. At this time Prometheus is still in a Tech
-Preview mode, with a non-production SLA. We encourage customers to explore
-Prometheus and its alerts, and to provide us feedback.
-
-More information about prometheus can be found in the
-link:https://docs.openshift.com/container-platform/3.11/install_config/cluster_metrics.html#openshift-prometheus[Prometheus
-documentation] for OpenShift.
-
-At this point, Prometheus is installed in your cluster. Until we configure
-administrative users, there is not much to do with it, though. The user
-authentication exercises will have you access Prometheus later, but, outside
-of this there currently are not any exercises for interacting with
-Prometheus. Look for these exercises to be added with the OpenShift 3.11
-release.
-
-Change to the `openshift-metrics` project:
-
-[source,bash,role="copypaste"]
-----
-oc project openshift-metrics
-----
-
-Now, `describe` the `StatefulSet` for Prometheus:
-
-[source,bash,role="copypaste"]
-----
-oc describe statefulset prometheus
-----
-
-You'll see something like the following:
-
-----
-Name:               prometheus
-Namespace:          openshift-metrics
-CreationTimestamp:  Wed, 24 Oct 2018 14:52:32 +0000
-Selector:           app=prometheus
-Labels:             app=prometheus
-Annotations:        <none>
-Replicas:           1 desired | 1 total
-Update Strategy:    RollingUpdate
-Pods Status:        1 Running / 0 Waiting / 0 Succeeded / 0 Failed
-Pod Template:
-  Labels:           app=prometheus
-  Service Account:  prometheus
-  Containers:
-   prom-proxy:
-    Image:      support.internal.aws.testdrive.openshift.com:5000/openshift3/oauth-proxy:v3.11.16
-    Port:       8443/TCP
-    Host Port:  0/TCP
-    Args:
-      -provider=openshift
-      -https-address=:8443
-...
-----
-
-`StatefulSet` is a special Kubernetes resource that deals with containers
-that have various startup and other dependencies. The key thing to note here
-is that Prometheus is actually made up of several containers, including
-authentication proxies (to secure it) and other components. There are six
-total containers in the core Prometheus stack.
-
-There is also a `node-exporter` container that runs as a `DaemonSet`. You can look at it by executing the following:
-
-[source,bash,role="copypaste"]
-----
-oc describe daemonset prometheus-node-exporter
-----
-
-You will see something like the following:
-
-----
-Name:           prometheus-node-exporter
-Selector:       app=prometheus-node-exporter,role=monitoring
-Node-Selector:  <none>
-Labels:         app=prometheus-node-exporter
-                role=monitoring
-Annotations:    kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"extensions/v1beta1","kind":"DaemonSet","metadata":{"annotations":{},"labels":{"app":"prometheus-node-exporter","role":"monitoring"},"nam...
-Desired Number of Nodes Scheduled: 5
-Current Number of Nodes Scheduled: 5
-Number of Nodes Scheduled with Up-to-date Pods: 5
-Number of Nodes Scheduled with Available Pods: 5
-Number of Nodes Misscheduled: 0
-Pods Status:  5 Running / 0 Waiting / 0 Succeeded / 0 Failed
-Pod Template:
-  Labels:           app=prometheus-node-exporter
-                    role=monitoring
-  Service Account:  prometheus-node-exporter
-  Containers:
-   node-exporter:
-    Image:      support.internal.aws.testdrive.openshift.com:5000/openshift3/prometheus-node-exporter:v3.11.16
-    Port:       9102/TCP
-    Host Port:  9102/TCP
-    Args:
-      --no-collector.wifi
-      --web.listen-address=:9102
-    Limits:
-      cpu:     200m
-      memory:  50Mi
-    Requests:
-      cpu:        100m
-      memory:     30Mi
-    Environment:  <none>
-    Mounts:
-      /host/proc from proc (ro)
-      /host/sys from sys (ro)
-  Volumes:
-   proc:
-    Type:          HostPath (bare host directory volume)
-    Path:          /proc
-    HostPathType:  
-   sys:
-    Type:          HostPath (bare host directory volume)
-    Path:          /sys
-    HostPathType:  
-Events:            <none>
-----
-
-A `DaemonSet` is another special Kubernetes resource. It makes sure that
-specified containers are running on certain nodes.
-
-There are no labs for these, so feel free to check the documentation for link:https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/[StatefulSet] and for link:https://docs.openshift.com/container-platform/3.11/dev_guide/daemonsets.html[DaemonSet].
-
-Lastly, you can view that the Prometheus components have been exposed for access when outside of OpenShift using `Routes`. You'll learn about `Routes` later:
-
-[source,bash,role="copypaste"]
-----
-oc get routes
-----
-
-You will see something like the following:
-
-----
-NAME           HOST/PORT                                                                      PATH      SERVICES       PORT      TERMINATION   WILDCARD
-alertmanager   alertmanager-openshift-metrics.{{OCP_ROUTING_SUFFIX}}             alertmanager   <all>     reencrypt     None
-alerts         alerts-openshift-metrics.{{OCP_ROUTING_SUFFIX}}                   alerts         <all>     reencrypt     None
-prometheus     prometheus-openshift-metrics.{{OCP_ROUTING_SUFFIX}}               prometheus     <all>     reencrypt     None
-----
-
-We will briefly come back to Prometheus once we're able to log in to it.
-
-#### Verify the Storage cluster
-In your environment Red Hat OpenShift Container Storage was installed as part of
-OpenShift. It will serve robust and persistent storage to both business
-applications as well as OpenShift infrastructure. It is based on Red Hat
-Gluster Storage, running in containers on OpenShift nodes and an additional
-API server called `heketi` that enables the API integration with OpenShift.
-
-We will now use a command line client on the *master* to talk via this server
-to the container storage cluster. It's password protected, so let's export a
-couple of environment variables first to configure the client:
-
-[source,bash,role="copypaste"]
-----
-export HEKETI_CLI_SERVER=http://heketi-storage-{{CNS_NAMESPACE}}.{{OCP_ROUTING_SUFFIX}}
-export HEKETI_CLI_USER=admin
-export HEKETI_CLI_KEY={{HEKETI_ADMIN_PW}}
-----
-
-Then use the CLI tool `heketi-cli` to query `heketi` about all the storage clusters it knows about:
-
-[source,bash,role="copypaste"]
-----
-heketi-cli cluster list
-----
-
-`heketi` will list all known clusters with internal UUIDs:
-
-----
-Clusters:
-ec7a9c8be8327a54839236791bf7ba24 [file][block]<1>
-----
-<1> This is the internal UUID of the OCS cluster
-
-[NOTE]
+[WARNING]
 ====
-The cluster UUID will be different for you since it's automatically generated.
+You will receive a self-signed certificate error in your browser when you
+first visit the web console. When OpenShift is installed, by default, a CA
+and SSL certificates are generated for all inter-component communication
+within OpenShift, including the web console.
 ====
-
-To get more detailed information about the topology of your OCS cluster (i.e.
-nodes, devices and volumes heketi has discovered) run the following command
-(output abbreviated):
-
-[source,bash,role="copypaste"]
-----
-heketi-cli topology info
-----
-
-You will get a lengthy output that describes the GlusterFS cluster topology as it is known by `heketi`:
-
-----
-Cluster Id: ec7a9c8be8327a54839236791bf7ba24
-
-    File:  true
-    Block: true
-
-    Volumes
-
-        Name: heketidbstorage <1>
-        Size: 2
-        Id: 272c8d37828c62c4002a19027abd2feb
-        Cluster Id: ec7a9c8be8327a54839236791bf7ba24
-        Mount: {{NODE1_INTERNAL_IP}}:heketidbstorage
-        Mount Options: backup-volfile-servers={{NODE2_INTERNAL_IP}},{{NODE2_INTERNAL_IP}}
-        Durability Type: replicate
-        Replica: 3
-        Snapshot: Disabled
-
-    Nodes:
-
-	Node Id: 099b016da11a623bef37de9b85aaa2d7
-	State: online
-	Cluster Id: ec7a9c8be8327a54839236791bf7ba24
-	Zone: 3
-	Management Hostname: {{NODE3_INTERNAL_FQDN}}
-	Storage Hostname: {{NODE3_INTERNAL_FQDN}}
-	Devices:
-		Id:e64fac664861c14bd75e3116f805b8fc   Name:/dev/xvdd           State:online    Size (GiB):49      Used (GiB):0       Free (GiB):49
-			Bricks:
-                            [...]
-
-	Node Id: 43336d05323e6003be6740dbb7477bd6
-	State: online
-	Cluster Id: ec7a9c8be8327a54839236791bf7ba24
-	Zone: 1
-	Management Hostname: {{NODE1_INTERNAL_FQDN}}
-	Storage Hostname: {{NODE1_INTERNAL_IP}}
-	Devices:
-		Id:11a148d8065f6a6220f89c2912d00d13   Name:/dev/xvdd           State:online    Size (GiB):49      Used (GiB):0       Free (GiB):49
-			Bricks:
-                            [...]
-
-	Node Id: 6c738028f642e37b2368eca88f8c626c
-	State: online
-	Cluster Id: ec7a9c8be8327a54839236791bf7ba24
-	Zone: 2
-	Management Hostname: {{NODE2_INTERNAL_FQDN}}
-	Storage Hostname: {{NODE2_INTERNAL_IP}}
-	Devices:
-		Id:cf7c0dfb258f07be25ac9cd4c4d2e6ae   Name:/dev/xvdd           State:online    Size (GiB):49      Used (GiB):0       Free (GiB):49
-			Bricks:
-                            [...]
-----
-<1> An internal GlusterFS volume that is automatically generated by the setup routine to hold the heketi database.
-
-This output tells you that Red Hat OpenShift Container Storage currently
-consists of a single cluster, which consists of 3 nodes, each with a single
-block device `/dev/xvdd` of 50GiB in size. The GlusterFS layer will turn
-these 3 devices/hosts into a single, flat storage pool from which OpenShift
-will be able to carve out either distinct filesystem volumes or block devices
-that serve as persistent storage for containers.


### PR DESCRIPTION
This is just the labs portion -- the automation has not yet been changed.

Notes:
* We probably need to change many of the images
* I removed the storage section from the app management basics only because there is not yet storage in the cluster at the time this lab is done. We will need to re-add the `volume` and other instructions to the new storage installation lab.