### PR TITLE
Fix login, link formatting, machine api ref, add note about disruption

### DIFF
--- a/labguide/infra-nodes.adoc
+++ b/labguide/infra-nodes.adoc
@@ -236,7 +236,7 @@ using are purposefully small.
 
 ### Extra Credit
 In the `openshift-machine-api` project are several `Pods`. One of them has a
-name like `clusterapi-manager-controllers-cc46df86c-2vrbp`. If you use `oc logs` on the
+name like `machine-api-controllers-56bdc6874f-86jnb`. If you use `oc logs` on the
 various containers in that `Pod`, you will see the various operator bits that
 actually make the nodes come into existence.
 
@@ -388,6 +388,11 @@ Run:
 ----
 oc get pod -n openshift-ingress -o wide
 ----
+
+[NOTE]
+====
+Your session may timeout during the router move. Please refresh the page to get your session back. You will not lose your terminal session but may have to navigate back to this page manually.
+====
 
 If you're quick enough, you might catch either `Terminating` or
 `ContainerCreating` pods. The `Terminating` pod was running on one of the

--- a/labguide/ldap-groupsync.adoc
+++ b/labguide/ldap-groupsync.adoc
@@ -164,7 +164,7 @@ To setup the LDAP identity provider we must:
 2. Create a `ConfigMap` with the CA certificate.
 3. Update the `cluster` `OAuth` object with the LDAP identity provider.
 
-As the `system:admin` user apply the OAuth configuration with `oc`.
+As the `kubeadmin` user apply the OAuth configuration with `oc`.
 
 [source,bash,role="execute"]
 ----
@@ -373,7 +373,7 @@ Make sure you login as the cluster administrator:
 
 [source,bash,role="execute"]
 ----
-oc login -u system:admin
+oc login -u kubeadmin -p {{ KUBEADMIN_PASSWORD }}
 ----
 
 Then, create several *Projects* for people to collaborate:

--- a/labguide/ocs4.adoc
+++ b/labguide/ocs4.adoc
@@ -407,27 +407,25 @@ rook-ceph-block   ceph.rook.io/block      8m27s
 
 Now you want to change which *storageclass* is default. 
 
-[source,bash,role="execute"]
-----
-oc edit sc gp2
-----
-
-Remove this portion shown below from *storageclass* `gp2`. Make sure to note
-*EXACTLY* where this annotations is located in the *storageclass* (copying
-this portion to clipboard would be a good idea). The editing tool is `vi`
-when using *oc edit*. Make sure to save your changes before exiting `:wq!`.
+We will be removing the following annotation from gp2 and add it to rook-ceph-block
 
 [source,yaml]
 ----
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 ----
+This should remove the annotation from gp2
+[source,bash,role="execute"]
+----
+oc annotate sc gp2 storageclass.kubernetes.io/is-default-class="false" --overwrite
+----
 
-Add the removed portion to `rook-ceph-block` in same place in the file so it will become the `default` *storageclass*. Make sure to save your changes before exiting `:wq!`. 
+
+The following will annotate rook-ceph-block so it will become the `default` *storageclass*.
 
 [source,bash,role="execute"]
 ----
-oc edit sc rook-ceph-block
+oc annotate sc rook-ceph-block storageclass.kubernetes.io/is-default-class="true"
 ----
 
 After editing *storageclass* `rook-ceph-block` the result should be similar
@@ -514,8 +512,7 @@ rails-pgsql-persistent   rails-pgsql-persistent-my-database-app.{{ ROUTE_SUBDOMA
 Copy the route path above to a browser window to create articles. You will
 need to append `/articles` to the end.
 
-*Select + Click this link:* http://rails-pgsql-persistent-my-database-app.{{
-*ROUTE_SUBDOMAIN }}/articles
+*Select + Click this link:* http://rails-pgsql-persistent-my-database-app.{{ ROUTE_SUBDOMAIN }}/articles
 
 Select the "New Article" link. Enter the `username` and `password` below to
 create articles and comments. The articles and comments are saved in a
@@ -805,6 +802,12 @@ ip-10-0-146-50.us-east-2.compute.internal    Ready    worker   2d2h    v1.13.4+d
 ip-10-0-156-83.us-east-2.compute.internal    Ready    worker   2d      v1.13.4+da48e8391
 ip-10-0-160-232.us-east-2.compute.internal   Ready    worker   2d2h    v1.13.4+da48e8391
 ip-10-0-164-65.us-east-2.compute.internal    Ready    worker   2d      v1.13.4+da48e8391
+----
+
+Until Openshift Container Platform 4.2 rolls out, we will need to restart (delete) the operator pod to see OSD pod added.
+[source,bash,role="execute"]
+----
+oc delete pod -l app=rook-ceph-operator -n rook-ceph
 ----
 
 This step could take 5 minutes or more for the forth *OSD* pod to be in a `Running` STATUS.


### PR DESCRIPTION
Fix login, link formatting, machine api ref, add note about disruption

Fixes openshift/openshift-cns-testdrive#441
- Uses kubeadmin with known password instead of system:admin which user don't have a certificate to.

Fix openshift/openshift-cns-testdrive#440
- fixes broken link ref

Fix openshift/openshift-cns-testdrive#439
- fixes orchestration not triggered related to rook/rook#2977
  - add restart operator pod instruction

Fix openshift/openshift-cns-testdrive#438
- simplified student operation
  - uses oc annotate instead of oc edit

Fixes openshift/openshift-cns-testdrive#437
- added a note about potential connection distruption

Fixes openshift/openshift-cns-testdrive#435
- switch to `machine-api-controllers-56bdc6874f-86jnb` replacing `clusterapi-manager-controllers-cc46df86c-2vrbp`