### PR TITLE
Add execute role to oc describe clusterversion

### DIFF
--- a/labguide/app-mgmt-basics.adoc
+++ b/labguide/app-mgmt-basics.adoc
@@ -644,7 +644,7 @@ commands you deployed an application, scaled it, and made it accessible to the
 outside world:
 
 ----
-oc new-app docker.io/siamaksade/mapit
+oc new-app quay.io/thoraxe/mapit
 oc scale --replicas=2 dc/mapit
 oc expose service mapit
 ----

--- a/labguide/installation.adoc
+++ b/labguide/installation.adoc
@@ -186,23 +186,40 @@ NAME      VERSION     AVAILABLE   PROGRESSING   SINCE   STATUS
 version   4.0.0-0.9   True        False         10h     Cluster version is 4.0.0-0.9
 ```
 
-For more details, you can use `oc describe clusterversion`:
+For more details, you can execute the following command:
 
+[source,bash,role="execute"]
+----
+oc describe clusterversion
+----
+
+Which will give you additional details, such as available updates:
 ```
 Name:         version
-Namespace:    
+Namespace:
 Labels:       <none>
 Annotations:  <none>
 API Version:  config.openshift.io/v1
 Kind:         ClusterVersion
 Metadata:
 ...
+Spec:
+  Channel:     stable-4.1
+  Cluster ID:  31fe51a5-12ab-4aa8-9ecc-ace4ff215d92
+  Upstream:    https://api.openshift.com/api/upgrades_info/v1/graph
+Status:
+  Available Updates:
+    Force:    false
+    Image:    quay.io/openshift-release-dev/ocp-release@sha256:a6c177eb007d20bb00bfd8
+f829e99bd40137167480112bd5ae1c25e40a4a163a
+    Version:  4.1.4
+...
   Desired:
-    Image:    quay.io/openshift-release-dev/ocp-release@sha256:345ec9351ecc1d78c16cf0853fe0ef2d9f48dd493da5fdffc18fa18f45707867
-    Version:  4.1.0-rc.0
-  Observed Generation:  1
-  Version Hash:         -XUey1xSiwE=
-Events:                 <none>
+    Force:    false
+    Image:    quay.io/openshift-release-dev/ocp-release@sha256:f852f9d8c2e81a633e874e
+57a7d9bdd52588002a9b32fc037dba12b67cf1f8b0
+    Version:  4.1.3
+...
 ```
 
 #### Look at the Nodes


### PR DESCRIPTION
To be consistent with the other commands available in the lab guide, add the execute role to this bash command and update the output to show a little more accurate detail.

And because I pushed one more change to this branch...fix the recap of what was done in the 'app management' module to reference the correct quay.io repo.