### PR TITLE
Remove machineset from cat to avoid an error, closes #455

### DIFF
--- a/labguide/ocs4.adoc
+++ b/labguide/ocs4.adoc
@@ -708,7 +708,7 @@ machine because of `replicas: 1` in the configuration file. Your
 
 [source,bash,role="execute"]
 ----
-cat machineset {{ HOME_PATH }}/content/support/cluster-workerocs-us-east-2a.yaml | more
+cat {{ HOME_PATH }}/content/support/cluster-workerocs-us-east-2a.yaml | more
 ----
 
 


### PR DESCRIPTION
I'd personally prefer something like 
```
less {{ HOME_PATH }}/content/support/cluster-workerocs-us-east-2a.yaml
```
but this minor change will remove the error