### PR TITLE
Fixed CCN Roadshow issues

### DIFF
--- a/workshop/content/environment.adoc
+++ b/workshop/content/environment.adoc
@@ -140,12 +140,12 @@ We will now run `oc whoami` to see what account you will be using today:
 oc whoami
 ----
 
-Let's inspect _admin-cluster-admin_ `ClusterRoleBinding` that gave our
+Let's inspect _cluster-admin_ `ClusterRoleBinding` that gave our
 `ServiceAccount` _cluster-admin_ `ClusterRole`:
 
 [source,bash,role="execute"]
 ----
-oc get clusterrolebinding admin-cluster-admin -o yaml
+oc get clusterrolebinding cluster-admin -o yaml
 ----
 
 Notice that our `ServiceAccount` is a subject in this `ClusterRoleBinding`

--- a/workshop/content/ldap-groupsync.adoc
+++ b/workshop/content/ldap-groupsync.adoc
@@ -373,7 +373,7 @@ Make sure you login as the cluster administrator:
 
 [source,bash,role="execute"]
 ----
-oc login -u system:serviceaccount:labguide:admin-user
+oc login -u kubeadmin -p {{ KUBEADMIN_PASSWORD }}
 ----
 
 Then, create several *Projects* for people to collaborate:


### PR DESCRIPTION
Before starting the CCN roadshow (12/19) in Taiwan, SA team found some issues below

1. Correct ServiceAccount name from `admin-cluster-admin` to `cluster-admin`
2. Fixed unknown user `system:serviceaccount:labguide:admin-user` to `kubeadmin`