### PR TITLE
Add the noobaa client to the Homeroom terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM quay.io/openshifthomeroom/workshop-dashboard:4.2.2
 
 USER root
 
+RUN wget https://github.com/noobaa/noobaa-operator/releases/download/v2.0.9/noobaa-linux-v2.0.9 -O /usr/bin/noobaa
+RUN chmod +x /usr/bin/noobaa
+
 COPY . /tmp/src
 
 RUN rm -rf /tmp/src/.git* && \


### PR DESCRIPTION
The noobaa client is used in the OCS4 module. We want to pre-install this inside Homeroom