### PR TITLE
Address issues found during testing January 3rd

### DIFF
--- a/workshop/content/environment.adoc
+++ b/workshop/content/environment.adoc
@@ -140,12 +140,12 @@ We will now run `oc whoami` to see what account you will be using today:
 oc whoami
 ----
 
-Let's inspect _admin-cluster-admin_ `ClusterRoleBinding` that gave our
+Let's inspect _dashboard-cluster-admin_ `ClusterRoleBinding` that gave our
 `ServiceAccount` _cluster-admin_ `ClusterRole`:
 
 [source,bash,role="execute"]
 ----
-oc get clusterrolebinding admin-cluster-admin -o yaml
+oc get clusterrolebinding dashboard-cluster-admin -o yaml
 ----
 
 Notice that our `ServiceAccount` is a subject in this `ClusterRoleBinding`

--- a/workshop/content/infra-nodes.adoc
+++ b/workshop/content/infra-nodes.adoc
@@ -57,9 +57,9 @@ metadata:
   creationTimestamp: 2019-01-25T16:00:34Z
   generation: 1
   labels:
-    sigs.k8s.io/cluster-api-cluster: 190125-3
-    sigs.k8s.io/cluster-api-machine-role: worker
-    sigs.k8s.io/cluster-api-machine-type: worker
+    machine.openshift.io/cluster-api-cluster: 190125-3
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
   name: 190125-3-worker-us-east-1b
   namespace: openshift-machine-api
   resourceVersion: "9027"
@@ -82,8 +82,8 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      sigs.k8s.io/cluster-api-cluster: 190125-3
-      sigs.k8s.io/cluster-api-machineset: 190125-3-worker-us-east-1b
+      machine.openshift.io/cluster-api-cluster: 190125-3
+      machine.openshift.io/cluster-api-machineset: 190125-3-worker-us-east-1b
 ```
 
 In this case, the cluster name is `190125-3` and there is an additional
@@ -99,10 +99,10 @@ make sure that things match here when we make changes:
     metadata:
       creationTimestamp: null
       labels:
-        sigs.k8s.io/cluster-api-cluster: 190125-3
-        sigs.k8s.io/cluster-api-machine-role: worker
-        sigs.k8s.io/cluster-api-machine-type: worker
-        sigs.k8s.io/cluster-api-machineset: 190125-3-worker-us-east-1b
+        machine.openshift.io/cluster-api-cluster: 190125-3
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: 190125-3-worker-us-east-1b
 ```
 
 #### Template Spec
@@ -134,9 +134,9 @@ Now that you've analyzed an existing `MachineSet` it's time to go over the
 rules for creating one, at least for a simple change like we're making:
 
 1. Don't change anything in the `providerSpec`
-2. Don't change any instances of `sigs.k8s.io/cluster-api-cluster: <clusterid>`
+2. Don't change any instances of `machine.openshift.io/cluster-api-cluster: <clusterid>`
 3. Give your `MachineSet` a unique `name`
-4. Make sure any instances of `sigs.k8s.io/cluster-api-machineset` match the `name`
+4. Make sure any instances of `machine.openshift.io/cluster-api-machineset` match the `name`
 5. Add labels you want on the nodes to `.spec.template.spec.metadata.labels`
 6. Even though you're changing `MachineSet` `name` references, be sure not to change the `subnet`.
 

--- a/workshop/content/ldap-groupsync.adoc
+++ b/workshop/content/ldap-groupsync.adoc
@@ -373,7 +373,7 @@ Make sure you login as the cluster administrator:
 
 [source,bash,role="execute"]
 ----
-oc login -u system:serviceaccount:labguide:admin-user
+oc login -u system:serviceaccount:lab-ocp-cns:dashboard-user
 ----
 
 Then, create several *Projects* for people to collaborate:

--- a/workshop/content/monitoring-basics.adoc
+++ b/workshop/content/monitoring-basics.adoc
@@ -65,7 +65,8 @@ In addition to the Alertmanager UI, OpenShift monitoring provides the
 queries of current metrics. This is useful when inspecting an alert as it
 allows queries for the alert's metric values over time.
 
-1. On the left hand side of the OpenShift Console, under the "Monitoring" section, click the link  for "Metrics".
+1. On the left hand side of the OpenShift Console, under the "Monitoring" section, click the link for "Metrics".
+1. At the top of "Metrics" page, click the link for "Prometheus UI".
 +
 [WARNING]
 ====
@@ -139,4 +140,3 @@ within OpenShift, including the Grafana dashboard.
 +
 .Dashboards UI (Grafana)
 image::grafana_dashboard.png[]
-


### PR DESCRIPTION
Performed testing of the workshop on January 3rd in preparation for an upcoming roadshow. My testing appeared to use OCP 4.2, and in running through it I found a few easily fixable issues.

The changes to environment.adoc and ldap-groupsync.adoc conflict with changes proposed in PR #479 - however, I believe the adjustments here are more in-line with the intent of the labs and use the cluster-admin service account.