### PR TITLE
minor formatting fixes

### DIFF
--- a/workshop/content/acm-multicluster.adoc
+++ b/workshop/content/acm-multicluster.adoc
@@ -1,10 +1,10 @@
-= Advanced Cluster Management for Kubernetes - RHACM 
+= Advanced Cluster Management for Kubernetes - RHACM
 
-== Working with Clusters and Cluster Lifecycle 
+== Working with Clusters and Cluster Lifecycle
 
 At a high level Cluster Lifecycle management is about creating, upgrading, and destroying and importing clusters in a multi cloud environment.
 
-In the demo console where you have all the credentials, you will find the *ACM Hub URL, Username and Password, AWS credentials*, *Access Key ID*, *Secret Access Key*, and the *Base DNS Domain*.  
+In the demo console where you have all the credentials, you will find the *ACM Hub URL, Username and Password, AWS credentials*, *Access Key ID*, *Secret Access Key*, and the *Base DNS Domain*.
 
 Once you have logged in to ACM, Navigate to *Credentials menu* and then select *Add Credentials*
 
@@ -12,27 +12,27 @@ Once you have logged in to ACM, Navigate to *Credentials menu* and then select *
 === You will need to provide connection details:
 
 * Cloud Provider Credentials: Choose *Amazon Web Services* +
-* Credential Name:  aws +
-* Namespace: open-cluster-management +
+* Credential Name:  `aws`
+* Namespace: `open-cluster-management`
 * Base DNS Domain:  This information is located on the demo console under the field *rhacm_aws_subdomain*
 
-_When copy and pasting this information, make sure you omit the dot on the url, for example it should read http://sandbox1536.opentlc.com[*sandbox1536.opentlc.com]** not .*http://sandbox1536.opentlc.com[*sandbox1536.opentlc.com]*_
+When copy and pasting this information, make sure you omit the dot on the url, for example it should read `sandbox1536.opentlc.com` not `.sandbox1536.opentlc.com`
 
 * Click NEXT
 
-* Access Key ID:  This information is located on the demo console under the field *rhacm_aws_access_key_id*
+* Access Key ID: This information is located on the demo console under the field *rhacm_aws_access_key_id*
 
 * Secret Access Key ID: This information is located on the demo console under the field *rhacm_aws_secret_key*
 
-* Click NEXT - We don’t need to configure a Proxy so we can skip this screen
+* Click NEXT - We don't need to configure a Proxy so we can skip this screen
 
 * Click NEXT
 
 * Red Hat OpenShift pull secret:  https://cloud.redhat.com/openshift/install/pull-secret[Get the pull secret from cloud.redhat.com - RH login Required]
 
-* SSH private and public keys:  Use an existing key pair or https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/credentials/credentials#aws_cred_create[generate a new ssh key[Get from your Red Hat login ]
+* SSH private and public keys:  Use an existing key pair or https://docs.openshift.com/container-platform/4.9/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default[generate a new ssh key]
 
-_Please note you might need *console.redhat.com* access to get these keys_+
+> Please note you might need *console.redhat.com* access to get these keys
 
 * Click NEXT
 
@@ -41,54 +41,56 @@ _Please note you might need *console.redhat.com* access to get these keys_+
 == Create a new OpenShift cluster in AWS
 
 
-* From the menu select *Infrastructure → Clusters* +
-* Click *Create Cluster* +
-* Select *Amazon Web services* +
-* Select the *Infrastructure provider credential* *AWS* 
-* Click NEXT +
-* Add the desired *cluster name*.  +
-* Leave the *Cluster set empty for now* +
-* Select a *Release Image*, chose a 4.9 version +
-* Add a label of *environment=prod* +
-* Click NEXT +
+* From the menu select *Infrastructure → Clusters*
+* Click *Create Cluster*
+* Select *Amazon Web services*
+* Select the *Infrastructure provider credential* *AWS*
+* Click NEXT
+* Add the desired *cluster name*.
+* Leave the *Cluster set empty for now*
+* Select a *Release Image*, chose a 4.9 version
+* Add a label of *environment=prod*
+* Click NEXT
 
-Change the region to *see table below* 
+Change the region to *see table below*
 
 |===
-|If you are located in *NORTH AMERICA*|Select *us-west-1* or *us-west-2*
+|Your Location | AWS Region to select
+|*NORTH AMERICA*|Select *us-west-1* or *us-west-2*
 
-|If you are located in *EUROPE / EMEA*|Select *eu-west-2* or *eu-west-3*
-|If you are located in *ASIA PACIFIC*|Select *ap-southeast-2* or *ap-northeast-2* or *ap-east-1*
+|*EUROPE / EMEA*|Select *eu-west-2* or *eu-west-3*
+|*ASIA PACIFIC*|Select *ap-southeast-2* or *ap-northeast-2* or *ap-east-1*
 |===
 
-* Click NEXT on the other screens or select *7 - Review* on the menu and then click *CREATE* 
+* Click NEXT on the other screens or select *7 - Review* on the menu and then click *CREATE*
 
 _This process takes about 30 to 40 minutes depending on AWS traffic at the time this course is taken. Make sure you monitor for any failures and address as needed_
 
-== Creating a Single Node Cluster (SNO) in AWS 
+== Creating a Single Node Cluster (SNO) in AWS
 
 While we wait for the main cluster to provision, lets go ahead and provision a Single Node Cluster. In this exercise we will show you how to create a single node cluster (OCP 4.8 and Above required) in order to save some time and resources when building clusters for testing.
 
 *Please NOTE* that provisioning SNO clusters in public clouds is not currently supported, we only support SNO clusters as bare metal, we leverage the public cloud in the example below to showcase the functionality only.
 
-* From the menu select *Infrastructure → Clusters* +
-* Click *Create Cluster* +
-* Select *Amazon Web services* +
-* Select the *Infrastructure provider credential*  *AWS*  +
-* Click NEXT +
-* Add the desired cluster name. Leave the Cluster set empty for now +
-* Select a *Release Image*, chose a *OCP 4.9 version* +
-* Add a label of *environment=qa* +
-* Click NEXT +
+* From the menu select *Infrastructure → Clusters*
+* Click *Create Cluster*
+* Select *Amazon Web services*
+* Select the *Infrastructure provider credential*  *AWS*
+* Click NEXT
+* Add the desired cluster name. Leave the Cluster set empty for now
+* Select a *Release Image*, chose a *OCP 4.9 version*
+* Add a label of *environment=qa*
+* Click NEXT
 
 * Change the region to *see table below*
 
 
 |===
-|If you are located in *NORTH AMERICA*|Select *us-west-1* or *us-west-2*
+|Your Location | AWS Region to select
+|*NORTH AMERICA*|Select *us-west-1* or *us-west-2*
 
-|If you are located in*EUROPE / EMEA*|Select *eu-west-2* or *eu-west-3*
-|If you are located in*ASIA PACIFIC*|Select *ap-southeast-2* or *ap-northeast-2* or *ap-east-1*
+|*EUROPE / EMEA*|Select *eu-west-2* or *eu-west-3*
+|*ASIA PACIFIC*|Select *ap-southeast-2* or *ap-northeast-2* or *ap-east-1*
 |===
 
 * Expand the *Worker Pools*, and change the worker node count to 0
@@ -97,23 +99,22 @@ While we wait for the main cluster to provision, lets go ahead and provision a S
 
 * Click on *install-config* in the YAML window pane and *change the master replica number to 1* (will likely be 3).  Double check that the worker replica is 0.
 
-* Click on *cluster* in the YAML window pane and locate the section where the *kind: MachinePool*.
-Double check that the worker replicas is set to 0.
+* Click on *cluster* in the YAML window pane and locate the section that defines an object of type: *kind: MachinePool*. Add the following add a line at the end of the *MachinePool* section.
+----
+  skipMachinePools: true
+----
 
-* And the following add a line at the end of the *MachinePool* section right 
-----
-+skipMachinePools:true
-----
+Be sure the new line is at the same indentation as the previous line.
 
 * Click on “*Create*” and the single node cluster creation will go through.
 
 _This process takes about 10 to 20 minutes depending on AWS traffic at the time this course is taken. Make sure you monitor for any failures and address as needed_
 
 
-== Creating and Managing Applications with Red Hat Advanced Cluster Management For Kubernetes 
+== Creating and Managing Applications with Red Hat Advanced Cluster Management For Kubernetes
 
 
-In the previous lab, you explored the Cluster Lifecycle functionality in RHACM. This allowed you to import an OpenShift® cluster to RHACM, which you can now use to deploy applications.
+In the previous lab, you explored the Cluster Lifecycle functionality in RHACM. This allowed you to create new OpenShift® clusters, which you can now use to deploy applications.
 
 Application Lifecycle functionality in RHACM provides the processes that are used to manage application resources on your managed clusters. This allows you to define a single or multi-cluster application using Kubernetes specifications, but with additional automation of the deployment and lifecycle management of resources to individual clusters. An application designed to run on a single cluster is straightforward and something you ought to be familiar with from working with OpenShift fundamentals. A multi-cluster application allows you to orchestrate the deployment of these same resources to multiple clusters, based on a set of rules you define for which clusters run the application components.
 
@@ -138,28 +139,28 @@ This may seem like a lot of extra resources to manage in addition to the deploya
 == Creating an Application
 
 
-Prerequisites:  
+Prerequisites:
 
 * Navigate to *Infrastructure → Clusters*
 * Click on the *local-cluster*
-* Click the *edit* button under *Labels* and add a *label* : *environment=dev*
+* Click the *edit* button under *Labels* and add a *label* : `environment=dev`
 * Verify the new clusters you build have the correct labels, it should be as follows:
-** *Local-Cluster* - *environment=dev*
-** *AWS 1st Cluster* - *environment=prod* 
-** *AWS 2nd Cluster* - *environment=qa*
+** *Local-Cluster* - `environment=dev`
+** *AWS 1st Cluster* - `environment=prod`
+** *AWS 2nd Cluster* - `environment=qa`
 
-* Navigate to *Applications* 
+* Navigate to *Applications*
 * Click *Create application, select Subscription*. Enter the following information:
-** *Name*: book-import 
-** *Namespace*: book-import 
+** *Name*: `book-import`
+** *Namespace*: `book-import`
 ** Under repository types, select the *GIT* repository
 ** *URL:*  https://github.com/hichammourad/book-import.git[https://github.com/hichammourad/book-import.git]
-** *Branch*:  master-no-pre-post
-** *Path:*  book-import
+** *Branch*:  `master-no-pre-post`
+** *Path:*  `book-import`
 
-* Verify that *Deploy application resources only on clusters matching specified labels *is selected and enter the following information 
-** *Label*: environment
-** *Value*: dev
+* Verify that *Deploy application resources only on clusters matching specified labels* is selected and enter the following information
+** *Label*: `environment`
+** *Value*: `dev`
 
 * Verify all the information is correct. Click *Create*
 
@@ -167,7 +168,7 @@ It will take a few minutes to deploy the application, *Click* on the *Topology* 
 
 Under the topology view, Select the *Route* and click on the *Launch Route* *URL*, this will take you to the Book Import application with several books available.
 
-Feel free to experiment with the application.  Edit it and change the label to *environment=prod*.  What happens to the application?
+Feel free to experiment with the application.  Edit it and change the label to `environment=prod`.  What happens to the application?
 
 You have now completed the overview of the *Application Lifecycle functionality in RHACM.*
 
@@ -175,19 +176,18 @@ You successfully deployed an application to a target cluster using RHACM. This a
 
 You also leverage the power of labels and deploy the application to your imported cluster. I highly encourage you to play around with the labels and deploy this application to your local cluster. You can also create other clusters and or applications if you so desire.
 
-
-
 == Governance, Risk, and Compliance (Security and compliance use case)
 
 === Creating Policies in ACM
 
 
-At this point, you have completed the overview labs for Cluster Lifecycle and Application Lifecycle capabilities in RHACM. In the Cluster Lifecycle Lab, you learned how RHACM can help manage the lifecycles of your Kubernetes clusters, including both deploying new clusters and importing existing clusters. In that lab, you configured your RHACM instance to manage an OpenShift® cluster.
+At this point, you have completed the overview labs for Cluster Lifecycle and Application Lifecycle capabilities in RHACM. In the Cluster Lifecycle Lab, you learned how RHACM can help manage the lifecycles of your Kubernetes clusters, including both deploying new clusters and importing existing clusters. In that lab, you created new clsters and used your RHACM instance to manage them.
 
 In the Application Lifecycle Lab, you continued exploring RHACM functionality and learned how to deploy and configure an application. You used the cluster that you added in the first module as the target for deploying an application.
 
-Now that you have a cluster and a deployed application, you need to make sure that they do not drift from their original configurations. This kind of drift is a serious problem, because it can happen from benign and benevolent fixes and changes, as well as malicious activities that you might not notice but can cause significant problems. The solution that RHACM provides for this is the Governance, Risk, and Compliance, or GRC, functionality. +
-Review GRC Functionality
+Now that you have a cluster and a deployed application, you need to make sure that they do not drift from their original configurations. This kind of drift is a serious problem, because it can happen from benign and benevolent fixes and changes, as well as malicious activities that you might not notice but can cause significant problems. The solution that RHACM provides for this is the Governance, Risk, and Compliance, or GRC, functionality.
+
+==== Review GRC Functionality
 
 To begin, it is important to define exactly what GRC is. In RHACM, you build policies that are applied to managed clusters. These policies can do different things, which are described below, but they ultimately serve to govern the configurations of your clusters. This governance over your cluster configurations reduces risk and ensures compliance with standards defined by stakeholders, which can include security teams and operations teams
 
@@ -208,31 +208,31 @@ You need to create three different resources in order to implement the policy co
 
 |Policy|The Policy defines what you actually want to check and possibly configure (with enforce). Policies include a policy-template which defines a list of objectDefinitions. The policy also determines the namespaces it is applied to, as well as the remediation actions it takes.
 |Placement Rule|Identifies a list of managed clusters that are targeted when using this PlacementRule.
-|PlacementBinding|Connect  the policy to the PlacementRule.
+|PlacementBinding|Connect the policy to the PlacementRule.
 |===
 
 
 This is a complex topic, and this course is only providing an overview. Please consult the https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html-single/governance/index#governance[GRC product documentation] for more details on any of these policy controllers.
 
-* Navigate to the *Governance* screen and click *create policy.* 
+* Navigate to the *Governance* screen and click *create policy.*
 * Navigate to the https://github.com/stolostron/policy-collection/tree/main/stable/CM-Configuration-Management[GitHub Repo] with all the policies and select the https://github.com/stolostron/policy-collection/blob/main/stable/SC-System-and-Communications-Protection/policy-etcdencryption.yaml[Etcd Encryption]
 * On the *ETCD Encryption Policy* click the *RAW* button on the policy.
 * Copy the raw YAML.
 * Under the *Create Policy* screen, enable the *YAML*. Copy and Paste the *RAW YAML* from the GitHub Repo
-* *Namespace*: default
-* Click on Step 5 and verify that everything is correct. 
+* *Namespace*: `default`
+* Click on Step 5 and verify that everything looks correct.
 * Click Submit.
 
-Navigate to the Results screen, allow the scan to complete, it shouldn’t take more than 3 minutes.
+Navigate to the Results screen, allow the scan to complete, it shouldn't take more than 3 minutes.
 
 Once complete notice the violations you have, since we created this policy as a Inform only it will not fix any of the violations, lets go ahead and fix them
 
 * On the top of the policy click on the *Actions → Edit Policy*
-* Select *Step 2 and change the Remediation to *Enforce*
-* Select *Step 5 review that is under Remediation is set to *Enforce*
-* Click Submit
+* Select *Step 2* and change the Remediation to *Enforce*
+* Select *Step 5* review that is under Remediation is set to *Enforce*
+* Click *Submit*
 
-Navigate to the Results screen, allow the remediation to complete, _it shouldn’t take more than 3 minutes_
+Navigate to the Results screen, allow the remediation to complete, _it shouldn't take more than 3 minutes_
 
 Now you have succesfully created a Policy to scan your clusters, if you would like to play with other policies please visit the https://github.com/stolostron/policy-collection[Policy Repo] for more Policies you can test out.
 


### PR DESCRIPTION
* Text formatting issues (occasional markdown/asciidoc syntax mixups, like random asterisks and the tables with region selections have header rows that are shaded when they should not be).
* The instruction to add skipMachinePools:true results in error bar underneath it when copy/pasted, because there is a “+” where there shouldn’t be, and no space after the colon.
* Text saying "This allowed you to import an OpenShift® cluster to RHACM” is misleading since we never import any clusters - we only make new ones 
* ssh instructions pointer update