### PR TITLE
Fix LDAP CA certificate in authentication lab

### DIFF
--- a/workshop/content/ldap-groupsync.adoc
+++ b/workshop/content/ldap-groupsync.adoc
@@ -184,16 +184,26 @@ This command will create a Kubernetes secret named "ldap-secret" in the "openshi
 oc create secret generic ldap-secret --from-literal=bindPassword=b1ndP^ssword -n openshift-config
 ----
 
-Download the certificate and save it to the file 'ca.crt' with this command:
+Extract the CA certificate chain directly from the JumpCloud LDAP server and
+save it to the file 'ca.crt' with this command:
 
 [source,bash,role="execute"]
 ----
-wget https://certs.godaddy.com/repository/gd-class2-root.crt -O {{ HOME_PATH }}/support/ca.crt
+openssl s_client -connect ldap.jumpcloud.com:636 -showcerts </dev/null 2>/dev/null \
+  | awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' \
+  | csplit -f {{ HOME_PATH }}/support/jc-cert- -b '%02d.pem' - '/BEGIN CERTIFICATE/' '{*}' 2>/dev/null \
+  && cat {{ HOME_PATH }}/support/jc-cert-02.pem {{ HOME_PATH }}/support/jc-cert-03.pem > {{ HOME_PATH }}/support/ca.crt \
+  && rm -f {{ HOME_PATH }}/support/jc-cert-*.pem
 ----
 
-----
-If you see `Unable to establish SSL connection.` please click the above command again before proceeding.
-----
+[NOTE]
+====
+Previous versions of this lab downloaded the GoDaddy Class 2 root certificate
+directly from GoDaddy's repository. That root is no longer part of the
+certificate chain served by JumpCloud's LDAP server, which now uses the GoDaddy
+G2 CA hierarchy. Extracting the chain from the server ensures the CA bundle
+always matches what the server presents.
+====
 
 Click this command to create a new ConfigMap named ca-config-map in the openshift-config namespace. The ConfigMap is populated with the contents of the file {{ HOME_PATH }}/support/ca.crt. It then applies the file.
 


### PR DESCRIPTION
## Summary

- The LDAP authentication lab instructs students to download `gd-class2-root.crt` from GoDaddy's repository, but JumpCloud's LDAP server (`ldaps://ldap.jumpcloud.com:636`) now uses the GoDaddy G2 CA hierarchy. The mismatch causes OAuth to fail with `x509: certificate signed by unknown authority`.
- Replace the static `wget` with an `openssl s_client` extraction that pulls the correct intermediate + root CA directly from the LDAP server, so the bundle always matches.

## How it was found

A customer workshop deployment ("OCP 4 for Admins") had LDAP authentication completely broken. The OAuth pods logged `tls: failed to verify certificate: x509: certificate signed by unknown authority` on every login attempt. Root cause was the wrong CA in the `ca-config-map` ConfigMap, traced back to this lab step.

## Test plan

- Deployed on a live workshop cluster (`cluster-xn4cp.sandbox5491.opentlc.com`) and verified:
  - `openssl s_client -connect ldap.jumpcloud.com:636 -CAfile ca.crt` returns `Verify return code: 0 (ok)`
  - `oc login -u normaluser1` succeeds after applying the corrected CA bundle
  - OAuth pods show zero TLS/LDAP errors

## Notes

The same issue exists on the `ocp4-prod` branch (line 190). A second PR can target that branch, or this fix can be cherry-picked after merge.