### PR TITLE
Use latest channel for OpenShift Pipelines subscription

### DIFF
--- a/support/gitops-catalog/pipelines-new/base/subscription.yaml
+++ b/support/gitops-catalog/pipelines-new/base/subscription.yaml
@@ -6,7 +6,7 @@ metadata:
   name: openshift-pipelines-operator-rh
   namespace: openshift-operators
 spec:
-  channel: pipelines-1.14
+  channel: latest
   installPlanApproval: Automatic
   name: openshift-pipelines-operator-rh
   source: redhat-operators


### PR DESCRIPTION
## Summary

- Changes `channel: pipelines-1.14` to `channel: latest` in the GitOps catalog Pipelines subscription
- The `pipelines-1.14` channel is not always present in the OCP 4.16 catalog, causing the GitOps module to fail with `ConstraintsNotSatisfiable`
- `latest` always resolves to the most recent stable Pipelines version for the cluster

## Context

Reported during a customer workshop -- the GitOps module's ArgoCD Application deploys this subscription, and the missing channel blocks Pipelines installation entirely. See [thread](https://redhat-internal.slack.com/archives/C04N203SNUW/p1784658038948279).

## Test plan

- [ ] Deploy workshop on OCP 4.16 cluster
- [ ] Run GitOps module -- ArgoCD should successfully install Pipelines via the `latest` channel