### PR TITLE
Remove TektonConfig from pipelines gitops catalog

### DIFF
--- a/support/gitops-catalog/pipelines-new/base/kustomization.yaml
+++ b/support/gitops-catalog/pipelines-new/base/kustomization.yaml
@@ -1,7 +1,2 @@
 resources:
 - subscription.yaml
-- tekton-config.yaml
-- clusterrole.yaml
-- clusterrolebinding.yaml
-# Partial needs more work, even with sync wave it fails. Suspect TektonInstaller needs health check so this doesn't get applied until it's ready
-# - tekton-config-metrics-partial.yaml


### PR DESCRIPTION
## Summary

- Removes TektonConfig, ClusterRole, and ClusterRoleBinding from the pipelines kustomization
- Keeps only the Subscription -- the Pipelines operator creates its own default TektonConfig on install
- Fixes the perpetual OutOfSync state in ArgoCD caused by the operator reconciling the TektonConfig and stripping ArgoCD tracking annotations

## Context

Follows #697 (channel fix). Even after fixing the channel, the pipelines ArgoCD Application stays OutOfSync because the TektonConfig resource drifts constantly between ArgoCD and the operator controller.

## Test plan

- [ ] Create pipelines Application in ArgoCD pointing to this branch
- [ ] Verify app shows Synced and Healthy
- [ ] Verify Pipelines operator is installed under Operators > Installed Operators